### PR TITLE
feat(compound-learning): add /index-learnings slash command

### DIFF
--- a/plugins/compound-learning/commands/index-learnings.md
+++ b/plugins/compound-learning/commands/index-learnings.md
@@ -1,0 +1,5 @@
+---
+description: Re-index all learning markdown files into ChromaDB
+---
+
+Run `Skill(skill="compound-learning:index-learnings")` and report the output.


### PR DESCRIPTION
## Summary
- Adds missing `/index-learnings` slash command to the compound-learning plugin
- The `index-learnings` skill documentation references this command but it wasn't available

## Problem
The SKILL.md file for index-learnings shows usage as `/index-learnings`, but there was no corresponding command file in `commands/` directory. This meant users couldn't invoke it as a slash command.

## Solution
Added `commands/index-learnings.md` following the same pattern as `start-learning-db.md`.

## Test plan
- [x] Verified command file follows existing pattern
- [ ] Test `/index-learnings` appears in Claude Code slash command autocomplete