### PR TITLE
Switch learning-writer agent from Sonnet to Haiku for faster, cheaper extraction

### DIFF
--- a/plugins/compound-learning/agents/learning-writer.md
+++ b/plugins/compound-learning/agents/learning-writer.md
@@ -1,7 +1,7 @@
 ---
 name: learning-writer
 description: Extracts learnings from conversation and writes focused markdown files
-model: sonnet
+model: haiku
 ---
 
 You are a Learning Writer. You analyze the current conversation and write small, focused learning files directly. You have access to the full conversation context already.


### PR DESCRIPTION
The learning-writer agent has a well-structured prompt with clear criteria,
making it suitable for Haiku. The consolidation-analyzer already uses Haiku
successfully. PR-learning-extractor remains on Sonnet due to higher complexity.

https://claude.ai/code/session_01YVeBcNTqi3AEnZCSfSHkNp