### PR TITLE
Add backward-compatibility checks for compound-learning

### DIFF
--- a/plugins/compound-learning/.claude-plugin/config.json
+++ b/plugins/compound-learning/.claude-plugin/config.json
@@ -5,6 +5,8 @@
   "learnings": {
     "globalDir": "${HOME}/.projects/learnings",
     "repoSearchPath": "${HOME}",
-    "distanceThreshold": 0.5
+    "highConfidenceThreshold": 0.4,
+    "possiblyRelevantThreshold": 0.55,
+    "keywordBoostWeight": 0.65
   }
 }

--- a/plugins/compound-learning/README.md
+++ b/plugins/compound-learning/README.md
@@ -38,7 +38,10 @@ Run `/index-learnings` to build the index. The SQLite database is created automa
 |----------|-------------|---------|
 | `LEARNINGS_GLOBAL_DIR` | Global learnings directory | `~/.projects/learnings` |
 | `LEARNINGS_REPO_SEARCH_PATH` | Base path to search for repo learnings | `~` |
-| `LEARNINGS_DISTANCE_THRESHOLD` | Similarity threshold (0-1, lower = more similar) | `0.5` |
+| `LEARNINGS_HIGH_CONFIDENCE_THRESHOLD` | Distance cutoff for `high_confidence` bucket (0-1, lower = more similar) | `0.40` |
+| `LEARNINGS_POSSIBLY_RELEVANT_THRESHOLD` | Distance cutoff for `possibly_relevant` bucket (0-1) | `0.55` |
+| `LEARNINGS_KEYWORD_BOOST_WEIGHT` | Keyword overlap rerank weight (0-1) | `0.65` |
+| `LEARNINGS_DISTANCE_THRESHOLD` | Legacy single-threshold fallback (used only when new threshold keys are unset) | _(legacy)_ |
 
 **Example in `.claude/settings.json`:**
 ```json
@@ -62,12 +65,19 @@ Create `.claude-plugin/config.json` in the plugin directory:
   "learnings": {
     "globalDir": "${HOME}/.projects/learnings",
     "repoSearchPath": "${HOME}",
-    "distanceThreshold": 0.5
+    "highConfidenceThreshold": 0.4,
+    "possiblyRelevantThreshold": 0.55,
+    "keywordBoostWeight": 0.65
   }
 }
 ```
 
 `${HOME}` expands to your home directory.
+
+Backward compatibility:
+- Legacy `learnings.distanceThreshold` and `LEARNINGS_DISTANCE_THRESHOLD` are still supported.
+- New keys take precedence when set (`highConfidenceThreshold`, `possiblyRelevantThreshold`, and their env vars).
+- Use legacy threshold only as a migration fallback; migrate to the new tiered keys when possible.
 
 ## Usage
 
@@ -143,6 +153,11 @@ Exit codes:
 - `2` runtime/config error
 
 Baseline file: `plugins/compound-learning/.claude-plugin/perf-baseline.json`
+
+Baseline backward compatibility:
+- Legacy top-level metric/workload schemas are accepted and normalized.
+- Legacy metric field aliases (`p50_ms`, `p95_ms`, `max_regression_percent`, `max_ms`) are accepted.
+- Missing fields are filled from defaults and reported in `warnings` instead of failing.
 
 Safe baseline update process:
 1. Run spotter after a clean performance improvement and confirm no regressions.
@@ -249,7 +264,7 @@ Use topic + context: "authentication JWT refresh" not "implement login feature"
 - Check config paths in `.claude-plugin/config.json`
 
 **Search returns no results:**
-- Check `distanceThreshold` setting (try increasing to 0.7)
+- Check `highConfidenceThreshold` / `possiblyRelevantThreshold` settings (legacy `distanceThreshold` still works as fallback)
 - Run `/index-learnings` to ensure learnings are indexed
 
 **Hook activity log:**

--- a/plugins/compound-learning/commands/perf-regression.md
+++ b/plugins/compound-learning/commands/perf-regression.md
@@ -34,4 +34,13 @@ The command prints JSON with:
 - `workload`: search iteration/query settings used
 - `metrics`: observed `p50`/`p95` for `total_search_ms`, `vector_search_ms`, `fts_ms`, `rerank_ms`
 - `regressions`: failed checks with threshold details
-- `warnings`: baseline fallback warnings (for missing metric fields)
+- `warnings`: compatibility/fallback warnings (legacy schema, missing fields, and defaults applied)
+
+## Baseline Compatibility
+
+Older baseline JSON files are accepted and normalized with warnings:
+- Top-level metric blocks (without a `metrics` wrapper)
+- Metric aliases (`p50_ms`, `p95_ms`, `max_regression_percent`, `max_ms`)
+- Top-level workload keys (`iterations`, `warmup_runs`, `queries`)
+
+Missing fields fall back to safe defaults instead of failing fast.

--- a/plugins/compound-learning/lib/db.py
+++ b/plugins/compound-learning/lib/db.py
@@ -30,6 +30,61 @@ _model = None
 _model_lock = threading.Lock()
 
 
+def _coerce_number(value: Any) -> float | None:
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+def _parse_env_float(name: str) -> float | None:
+    raw = os.environ.get(name)
+    if raw is None:
+        return None
+    try:
+        return float(raw)
+    except ValueError:
+        print(f"Warning: Ignoring invalid {name}={raw!r}; expected a numeric value.", file=sys.stderr)
+        return None
+
+
+def _apply_legacy_threshold_compat(
+    result: Dict[str, Any],
+    learnings_file_config: Dict[str, Any],
+    env_legacy_threshold: float | None,
+    env_high_threshold: float | None,
+    env_possible_threshold: float | None,
+) -> None:
+    has_file_high = 'highConfidenceThreshold' in learnings_file_config
+    has_file_possible = 'possiblyRelevantThreshold' in learnings_file_config
+
+    legacy_file_threshold = _coerce_number(learnings_file_config.get('distanceThreshold'))
+    if 'distanceThreshold' in learnings_file_config and legacy_file_threshold is None:
+        print(
+            "Warning: Ignoring non-numeric learnings.distanceThreshold in config file.",
+            file=sys.stderr,
+        )
+
+    # Legacy config fallback: honor learnings.distanceThreshold when newer keys are missing.
+    if legacy_file_threshold is not None:
+        if not has_file_high:
+            result['learnings']['highConfidenceThreshold'] = legacy_file_threshold
+        if not has_file_possible:
+            result['learnings']['possiblyRelevantThreshold'] = max(
+                float(result['learnings']['possiblyRelevantThreshold']),
+                legacy_file_threshold,
+            )
+
+    # Legacy env fallback follows same rule, but never overrides explicit new env vars.
+    if env_legacy_threshold is not None:
+        if env_high_threshold is None and not has_file_high:
+            result['learnings']['highConfidenceThreshold'] = env_legacy_threshold
+        if env_possible_threshold is None and not has_file_possible:
+            result['learnings']['possiblyRelevantThreshold'] = max(
+                float(result['learnings']['possiblyRelevantThreshold']),
+                env_legacy_threshold,
+            )
+
+
 def load_config() -> Dict[str, Any]:
     """Load configuration from environment variables, then config file, then defaults."""
     home = os.path.expanduser('~')
@@ -73,12 +128,27 @@ def load_config() -> Dict[str, Any]:
         except Exception as e:
             print(f"Warning: Failed to load config from {config_file}: {e}", file=sys.stderr)
 
+    learnings_file_config: Dict[str, Any] = {}
+    if isinstance(file_config.get('learnings'), dict):
+        learnings_file_config = file_config['learnings']
+
     # Env var overrides
     env_db_path = os.environ.get('SQLITE_DB_PATH')
     env_global_dir = os.environ.get('LEARNINGS_GLOBAL_DIR')
     env_repo_path = os.environ.get('LEARNINGS_REPO_SEARCH_PATH')
+    env_legacy_threshold = _parse_env_float('LEARNINGS_DISTANCE_THRESHOLD')
+    env_high_threshold = _parse_env_float('LEARNINGS_HIGH_CONFIDENCE_THRESHOLD')
+    env_possible_threshold = _parse_env_float('LEARNINGS_POSSIBLY_RELEVANT_THRESHOLD')
+    env_keyword_boost_weight = _parse_env_float('LEARNINGS_KEYWORD_BOOST_WEIGHT')
 
     result = _deep_merge(defaults, file_config)
+    _apply_legacy_threshold_compat(
+        result=result,
+        learnings_file_config=learnings_file_config,
+        env_legacy_threshold=env_legacy_threshold,
+        env_high_threshold=env_high_threshold,
+        env_possible_threshold=env_possible_threshold,
+    )
 
     if env_db_path:
         result['sqlite']['dbPath'] = os.path.expanduser(env_db_path)
@@ -86,6 +156,24 @@ def load_config() -> Dict[str, Any]:
         result['learnings']['globalDir'] = os.path.expanduser(env_global_dir)
     if env_repo_path:
         result['learnings']['repoSearchPath'] = os.path.expanduser(env_repo_path)
+    if env_high_threshold is not None:
+        result['learnings']['highConfidenceThreshold'] = env_high_threshold
+    if env_possible_threshold is not None:
+        result['learnings']['possiblyRelevantThreshold'] = env_possible_threshold
+    if env_keyword_boost_weight is not None:
+        result['learnings']['keywordBoostWeight'] = env_keyword_boost_weight
+
+    high = result['learnings']['highConfidenceThreshold']
+    possible = result['learnings']['possiblyRelevantThreshold']
+    if isinstance(high, (int, float)) and isinstance(possible, (int, float)) and possible < high:
+        print(
+            (
+                "Warning: learnings.possiblyRelevantThreshold is lower than "
+                "learnings.highConfidenceThreshold; aligning it to match high confidence threshold."
+            ),
+            file=sys.stderr,
+        )
+        result['learnings']['possiblyRelevantThreshold'] = float(high)
 
     return result
 

--- a/plugins/compound-learning/scripts/perf-regression-spotter.py
+++ b/plugins/compound-learning/scripts/perf-regression-spotter.py
@@ -104,6 +104,13 @@ DEFAULT_METRIC_THRESHOLDS: Dict[str, Dict[str, float]] = {
     },
 }
 
+METRIC_FIELD_ALIASES: Dict[str, Tuple[str, ...]] = {
+    'p50_baseline_ms': ('p50_ms', 'baseline_p50_ms'),
+    'p95_baseline_ms': ('p95_ms', 'baseline_p95_ms'),
+    'max_regression_pct': ('max_regression_percent',),
+    'absolute_cap_ms': ('absolute_max_ms', 'max_ms'),
+}
+
 
 def _coerce_number(value: Any) -> float | None:
     if isinstance(value, (int, float)):
@@ -118,11 +125,43 @@ def _default_baseline() -> Dict[str, Dict[str, float]]:
     }
 
 
-def _load_workload_settings(raw: Dict[str, Any]) -> Dict[str, Any]:
+def _metric_field_names(field: str) -> Tuple[str, ...]:
+    aliases = METRIC_FIELD_ALIASES.get(field, ())
+    return (field, *aliases)
+
+
+def _extract_metric_field(
+    metric: str,
+    metric_cfg: Dict[str, Any],
+    field: str,
+    warnings: List[str],
+) -> float | None:
+    for name in _metric_field_names(field):
+        value = _coerce_number(metric_cfg.get(name))
+        if value is None:
+            continue
+        if name != field:
+            warnings.append(
+                f"Metric '{metric}' uses legacy field '{name}'; prefer '{field}'."
+            )
+        return value
+    return None
+
+
+def _load_workload_settings(raw: Dict[str, Any], warnings: List[str]) -> Dict[str, Any]:
     workload = dict(DEFAULT_WORKLOAD)
     section = raw.get('workload')
     if not isinstance(section, dict):
-        return workload
+        legacy_section: Dict[str, Any] = {}
+        for key in ('iterations', 'warmup_runs', 'queries'):
+            if key in raw:
+                legacy_section[key] = raw.get(key)
+        if not legacy_section:
+            return workload
+        warnings.append(
+            "Baseline uses legacy top-level workload fields; prefer the 'workload' object."
+        )
+        section = legacy_section
 
     iterations = section.get('iterations')
     if isinstance(iterations, int) and iterations > 0:
@@ -164,18 +203,42 @@ def load_baseline(path: Path) -> Tuple[Dict[str, Any], List[str]]:
         raise ValueError(f'Baseline file {path} must be a JSON object.')
 
     raw_metrics = raw.get('metrics')
+    if not isinstance(raw_metrics, dict):
+        legacy_metrics = {metric: raw.get(metric) for metric in REQUIRED_METRICS if metric in raw}
+        if legacy_metrics:
+            raw_metrics = legacy_metrics
+            warnings.append(
+                "Baseline uses legacy top-level metric fields; prefer nesting under 'metrics'."
+            )
+
     normalized_metrics = _default_baseline()
     if not isinstance(raw_metrics, dict):
         warnings.append('Baseline metrics block missing or invalid; using default thresholds.')
     else:
         for metric in REQUIRED_METRICS:
             metric_cfg = raw_metrics.get(metric)
-            if not isinstance(metric_cfg, dict):
+            if metric_cfg is None:
                 warnings.append(f"Metric '{metric}' missing; using defaults for this metric.")
+                continue
+            if isinstance(metric_cfg, (int, float)):
+                scalar = float(metric_cfg)
+                warnings.append(
+                    (
+                        f"Metric '{metric}' uses legacy scalar value; applying {scalar} ms "
+                        "to both p50/p95 baselines."
+                    )
+                )
+                normalized_metrics[metric]['p50_baseline_ms'] = scalar
+                normalized_metrics[metric]['p95_baseline_ms'] = scalar
+                continue
+            if not isinstance(metric_cfg, dict):
+                warnings.append(
+                    f"Metric '{metric}' is not an object; using defaults for this metric."
+                )
                 continue
 
             for field in ('p50_baseline_ms', 'p95_baseline_ms', 'max_regression_pct', 'absolute_cap_ms'):
-                value = _coerce_number(metric_cfg.get(field))
+                value = _extract_metric_field(metric, metric_cfg, field, warnings)
                 if value is None:
                     warnings.append(
                         f"Metric '{metric}' missing '{field}'; using default value "
@@ -187,7 +250,7 @@ def load_baseline(path: Path) -> Tuple[Dict[str, Any], List[str]]:
     return {
         'source': str(path),
         'metrics': normalized_metrics,
-        'workload': _load_workload_settings(raw),
+        'workload': _load_workload_settings(raw, warnings),
     }, warnings
 
 

--- a/plugins/compound-learning/tests/test_config_backward_compat.py
+++ b/plugins/compound-learning/tests/test_config_backward_compat.py
@@ -1,0 +1,111 @@
+import json
+import sys
+from pathlib import Path
+
+
+PLUGIN_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(PLUGIN_ROOT))
+
+import lib.db as db
+
+
+_CONFIG_ENV_VARS = (
+    'CLAUDE_PLUGIN_ROOT',
+    'SQLITE_DB_PATH',
+    'LEARNINGS_GLOBAL_DIR',
+    'LEARNINGS_REPO_SEARCH_PATH',
+    'LEARNINGS_DISTANCE_THRESHOLD',
+    'LEARNINGS_HIGH_CONFIDENCE_THRESHOLD',
+    'LEARNINGS_POSSIBLY_RELEVANT_THRESHOLD',
+    'LEARNINGS_KEYWORD_BOOST_WEIGHT',
+)
+
+
+def _write_config(plugin_root: Path, config: dict) -> None:
+    cfg_dir = plugin_root / '.claude-plugin'
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    (cfg_dir / 'config.json').write_text(json.dumps(config), encoding='utf-8')
+
+
+def _reset_env(monkeypatch, plugin_root: Path) -> None:
+    for key in _CONFIG_ENV_VARS:
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv('CLAUDE_PLUGIN_ROOT', str(plugin_root))
+
+
+def test_legacy_distance_threshold_is_honored_when_new_keys_are_missing(tmp_path, monkeypatch):
+    plugin_root = tmp_path / 'plugin'
+    _write_config(
+        plugin_root,
+        {
+            'learnings': {
+                'distanceThreshold': 0.5,
+            }
+        },
+    )
+    _reset_env(monkeypatch, plugin_root)
+
+    config = db.load_config()
+
+    assert config['learnings']['highConfidenceThreshold'] == 0.5
+    assert config['learnings']['possiblyRelevantThreshold'] == 0.55
+
+
+def test_new_threshold_keys_take_precedence_over_legacy_distance_threshold(tmp_path, monkeypatch):
+    plugin_root = tmp_path / 'plugin'
+    _write_config(
+        plugin_root,
+        {
+            'learnings': {
+                'distanceThreshold': 0.9,
+                'highConfidenceThreshold': 0.41,
+                'possiblyRelevantThreshold': 0.58,
+            }
+        },
+    )
+    _reset_env(monkeypatch, plugin_root)
+
+    config = db.load_config()
+
+    assert config['learnings']['highConfidenceThreshold'] == 0.41
+    assert config['learnings']['possiblyRelevantThreshold'] == 0.58
+
+
+def test_new_env_thresholds_override_legacy_env_and_config(tmp_path, monkeypatch):
+    plugin_root = tmp_path / 'plugin'
+    _write_config(
+        plugin_root,
+        {
+            'learnings': {
+                'distanceThreshold': 0.62,
+            }
+        },
+    )
+    _reset_env(monkeypatch, plugin_root)
+    monkeypatch.setenv('LEARNINGS_DISTANCE_THRESHOLD', '0.88')
+    monkeypatch.setenv('LEARNINGS_HIGH_CONFIDENCE_THRESHOLD', '0.33')
+    monkeypatch.setenv('LEARNINGS_POSSIBLY_RELEVANT_THRESHOLD', '0.44')
+
+    config = db.load_config()
+
+    assert config['learnings']['highConfidenceThreshold'] == 0.33
+    assert config['learnings']['possiblyRelevantThreshold'] == 0.44
+
+
+def test_legacy_env_threshold_applies_when_new_keys_are_not_set(tmp_path, monkeypatch):
+    plugin_root = tmp_path / 'plugin'
+    _write_config(
+        plugin_root,
+        {
+            'learnings': {
+                'distanceThreshold': 0.5,
+            }
+        },
+    )
+    _reset_env(monkeypatch, plugin_root)
+    monkeypatch.setenv('LEARNINGS_DISTANCE_THRESHOLD', '0.62')
+
+    config = db.load_config()
+
+    assert config['learnings']['highConfidenceThreshold'] == 0.62
+    assert config['learnings']['possiblyRelevantThreshold'] == 0.62

--- a/plugins/compound-learning/tests/test_perf_regression_spotter.py
+++ b/plugins/compound-learning/tests/test_perf_regression_spotter.py
@@ -2,7 +2,7 @@ import importlib.util
 import json
 import sys
 from pathlib import Path
-from typing import Dict
+from typing import Dict, List
 
 
 PLUGIN_ROOT = Path(__file__).parent.parent
@@ -192,3 +192,118 @@ def test_search_execute_collects_timing_metrics(monkeypatch):
     assert result['exit_code'] == 0
     for metric in search_mod.TIMING_KEYS:
         assert metric in result['timings']
+
+
+def test_load_baseline_supports_legacy_top_level_schema(tmp_path):
+    baseline_path = tmp_path / 'legacy-baseline.json'
+    baseline_path.write_text(
+        json.dumps(
+            {
+                'iterations': 3,
+                'warmup_runs': 0,
+                'queries': ['jwt refresh token'],
+                'total_search_ms': {
+                    'p50_ms': 111.0,
+                    'p95_ms': 222.0,
+                    'max_regression_percent': 40.0,
+                    'max_ms': 900.0,
+                },
+                'vector_search_ms': 175.0,
+            }
+        ),
+        encoding='utf-8',
+    )
+
+    baseline, warnings = spotter.load_baseline(baseline_path)
+
+    total_cfg = baseline['metrics']['total_search_ms']
+    assert total_cfg['p50_baseline_ms'] == 111.0
+    assert total_cfg['p95_baseline_ms'] == 222.0
+    assert total_cfg['max_regression_pct'] == 40.0
+    assert total_cfg['absolute_cap_ms'] == 900.0
+
+    vector_cfg = baseline['metrics']['vector_search_ms']
+    assert vector_cfg['p50_baseline_ms'] == 175.0
+    assert vector_cfg['p95_baseline_ms'] == 175.0
+    assert vector_cfg['max_regression_pct'] == spotter.DEFAULT_METRIC_THRESHOLDS['vector_search_ms']['max_regression_pct']
+    assert vector_cfg['absolute_cap_ms'] == spotter.DEFAULT_METRIC_THRESHOLDS['vector_search_ms']['absolute_cap_ms']
+
+    assert baseline['workload']['iterations'] == 3
+    assert baseline['workload']['warmup_runs'] == 0
+    assert baseline['workload']['queries'] == ['jwt refresh token']
+    assert warnings
+
+
+def test_search_execute_no_results_output_contract_stable(monkeypatch):
+    config = {
+        'learnings': {
+            'highConfidenceThreshold': 0.4,
+            'possiblyRelevantThreshold': 0.55,
+            'keywordBoostWeight': 0.65,
+        }
+    }
+
+    class DummyConn:
+        def close(self):
+            return None
+
+    monkeypatch.setattr(search_mod.db, 'load_config', lambda: config)
+    monkeypatch.setattr(search_mod, 'detect_learning_hierarchy', lambda cwd, home: ['example-repo'])
+    monkeypatch.setattr(search_mod, 'query_single_keyword', lambda *args, **kwargs: [])
+    monkeypatch.setattr(search_mod.db, 'get_connection', lambda cfg: DummyConn())
+    monkeypatch.setattr(search_mod, 'fts5_search', lambda conn, query_text: set())
+
+    result = search_mod.execute_search(query='jwt refresh token')
+    output = result['output']
+
+    assert result['exit_code'] == 0
+    assert output['status'] == 'no_results'
+    assert output['query'] == 'jwt refresh token'
+    assert output['repos_searched'] == ['example-repo']
+    assert output['high_confidence'] == []
+    assert output['possibly_relevant'] == []
+
+
+def test_search_execute_invalid_keywords_json_falls_back_to_query(monkeypatch):
+    config = {
+        'learnings': {
+            'highConfidenceThreshold': 0.4,
+            'possiblyRelevantThreshold': 0.55,
+            'keywordBoostWeight': 0.65,
+        }
+    }
+    seen_keywords: List[str] = []
+
+    class DummyConn:
+        def close(self):
+            return None
+
+    def _query_single_keyword(config, keyword, scope_repos, query_size):  # noqa: ANN001
+        seen_keywords.append(keyword)
+        return [
+            {
+                'id': 'doc-1',
+                'document': 'JWT refresh token rotation',
+                'metadata': {},
+                'distance': 0.2,
+            }
+        ]
+
+    monkeypatch.setattr(search_mod.db, 'load_config', lambda: config)
+    monkeypatch.setattr(search_mod, 'detect_learning_hierarchy', lambda cwd, home: [])
+    monkeypatch.setattr(search_mod, 'query_single_keyword', _query_single_keyword)
+    monkeypatch.setattr(search_mod.db, 'get_connection', lambda cfg: DummyConn())
+    monkeypatch.setattr(search_mod, 'fts5_search', lambda conn, query_text: {'doc-1'})
+
+    result = search_mod.execute_search(
+        query='jwt refresh token',
+        keywords_json='not-valid-json',
+        peek_mode=True,
+    )
+    output = result['output']
+
+    assert result['exit_code'] == 0
+    assert seen_keywords == ['jwt refresh token']
+    assert output['status'] == 'found'
+    assert output['keywords_searched'] == ['jwt refresh token']
+    assert {'status', 'count', 'keywords_searched', 'learnings'}.issubset(output.keys())


### PR DESCRIPTION
## Summary
- preserve legacy threshold compatibility in compound-learning config loading while keeping new key/env precedence
- make perf baseline loading tolerant of legacy/partial schemas with warnings and safe defaults
- add compatibility-focused tests for config migration behavior, perf baseline parsing, and search output contract defaults
- document legacy support and migration path in plugin docs/config examples

## Validation
- pytest -q plugins/compound-learning/tests/test_config_backward_compat.py plugins/compound-learning/tests/test_perf_regression_spotter.py