### PR TITLE
Add structured observability instrumentation to compound-learning

### DIFF
--- a/plugins/compound-learning/.claude-plugin/config.json
+++ b/plugins/compound-learning/.claude-plugin/config.json
@@ -6,5 +6,10 @@
     "globalDir": "${HOME}/.projects/learnings",
     "repoSearchPath": "${HOME}",
     "distanceThreshold": 0.5
+  },
+  "observability": {
+    "enabled": false,
+    "level": "info",
+    "logPath": "${HOME}/.claude/plugins/compound-learning/observability.jsonl"
   }
 }

--- a/plugins/compound-learning/README.md
+++ b/plugins/compound-learning/README.md
@@ -39,6 +39,9 @@ Run `/index-learnings` to build the index. The SQLite database is created automa
 | `LEARNINGS_GLOBAL_DIR` | Global learnings directory | `~/.projects/learnings` |
 | `LEARNINGS_REPO_SEARCH_PATH` | Base path to search for repo learnings | `~` |
 | `LEARNINGS_DISTANCE_THRESHOLD` | Similarity threshold (0-1, lower = more similar) | `0.5` |
+| `LEARNINGS_OBS_ENABLED` | Enable structured observability events (`true`/`false`) | `false` |
+| `LEARNINGS_OBS_LEVEL` | Minimum observability level (`debug`, `info`, `warn`, `error`) | `info` |
+| `LEARNINGS_OBS_LOG_PATH` | JSONL observability log path | `~/.claude/plugins/compound-learning/observability.jsonl` |
 
 **Example in `.claude/settings.json`:**
 ```json
@@ -63,11 +66,26 @@ Create `.claude-plugin/config.json` in the plugin directory:
     "globalDir": "${HOME}/.projects/learnings",
     "repoSearchPath": "${HOME}",
     "distanceThreshold": 0.5
+  },
+  "observability": {
+    "enabled": false,
+    "level": "info",
+    "logPath": "${HOME}/.claude/plugins/compound-learning/observability.jsonl"
   }
 }
 ```
 
 `${HOME}` expands to your home directory.
+
+### Observability Events
+
+When observability is enabled, the plugin writes structured JSONL events for:
+- Hooks (`setup`, `auto-peek`, `extract-learnings`) including start/end/skip/subprocess exit/duration
+- Search pipeline (keyword parse, repo scope, fan-out, merge/rerank/filter, threshold buckets, final status)
+- Index pipeline (discovery, per-file failures, prune summary, manifest generation, total runtime)
+- DB operations (connection open, schema init, embeddings, upsert/delete/vector search)
+
+Event fields include: `timestamp`, `level`, `component`, `operation`, `status`, `duration_ms`, `counts`, optional `error`, and correlation/session identifiers when available.
 
 ## Usage
 
@@ -217,3 +235,7 @@ Use topic + context: "authentication JWT refresh" not "implement login feature"
 
 **Hook activity log:**
 - Hook activity is logged to `~/.claude/plugins/compound-learning/activity.log`
+
+**Observability log:**
+- Structured events are logged to `~/.claude/plugins/compound-learning/observability.jsonl` (or `LEARNINGS_OBS_LOG_PATH`)
+- Tail recent events with: `tail -f ~/.claude/plugins/compound-learning/observability.jsonl`

--- a/plugins/compound-learning/hooks/auto-peek.sh
+++ b/plugins/compound-learning/hooks/auto-peek.sh
@@ -4,22 +4,53 @@
 # Uses Haiku to extract keywords, then searches SQLite
 # Output is added as context Claude can see
 
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$HOOK_DIR/observability.sh" || exit 0
+
+hook_log_init "auto-peek"
+SESSION_ID="${CLAUDE_SESSION_ID:-}"
+HOOK_OUTCOME="success"
+HOOK_OUTCOME_MESSAGE=""
+RESULT_COUNT=0
+KEYWORD_COUNT=0
+EMPTY_MCP=""
+
+auto_peek_finalize() {
+  if [ -n "$EMPTY_MCP" ] && [ -f "$EMPTY_MCP" ]; then
+    rm -f "$EMPTY_MCP"
+  fi
+  local duration_ms
+  duration_ms="$(hook_elapsed_ms)"
+  local level="info"
+  case "$HOOK_OUTCOME" in
+    success) level="info" ;;
+    skipped) level="info" ;;
+    error) level="error" ;;
+    *) level="warn" ;;
+  esac
+  hook_obs_event "$level" "hook_end" "$HOOK_OUTCOME" \
+    --duration-ms "$duration_ms" \
+    --session-id "$SESSION_ID" \
+    --message "$HOOK_OUTCOME_MESSAGE" \
+    --counts-json "{\"result_count\":$RESULT_COUNT,\"keyword_count\":$KEYWORD_COUNT}"
+}
+trap auto_peek_finalize EXIT
+
+hook_obs_event "info" "hook_start" "start" --session-id "$SESSION_ID"
+
 # Bail if plugin root not set
 if [ -z "$CLAUDE_PLUGIN_ROOT" ]; then
+  HOOK_OUTCOME="skipped"
+  HOOK_OUTCOME_MESSAGE="CLAUDE_PLUGIN_ROOT not set"
+  hook_obs_event "info" "skip_reason" "skipped" --message "plugin root not set" --session-id "$SESSION_ID"
   exit 0
 fi
 
-# Setup logging
-LOG_DIR="$HOME/.claude/plugins/compound-learning"
-mkdir -p "$LOG_DIR"
-LOG_FILE="$LOG_DIR/activity.log"
-
-log_activity() {
-  echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" >> "$LOG_FILE"
-}
-
 # Skip all hooks for subprocess calls (prevents recursion)
 if [ -n "$CLAUDE_SUBPROCESS" ]; then
+  HOOK_OUTCOME="skipped"
+  HOOK_OUTCOME_MESSAGE="Skipping in subprocess context"
+  hook_obs_event "info" "skip_reason" "skipped" --message "CLAUDE_SUBPROCESS is set" --session-id "$SESSION_ID"
   exit 0
 fi
 
@@ -27,13 +58,23 @@ fi
 INPUT=$(cat)
 PROMPT=$(echo "$INPUT" | jq -r '.prompt')
 TRANSCRIPT=$(echo "$INPUT" | jq -r '.transcript_path')
+SESSION_FROM_INPUT=$(echo "$INPUT" | jq -r '.session_id // empty')
+if [ -n "$SESSION_FROM_INPUT" ] && [ "$SESSION_FROM_INPUT" != "null" ]; then
+  SESSION_ID="$SESSION_FROM_INPUT"
+fi
 if [ -z "$TRANSCRIPT" ] || [ "$TRANSCRIPT" = "null" ]; then
+  HOOK_OUTCOME="skipped"
+  HOOK_OUTCOME_MESSAGE="No transcript path provided"
+  hook_obs_event "info" "skip_reason" "skipped" --message "missing transcript path" --session-id "$SESSION_ID"
   exit 0
 fi
 CWD=$(echo "$INPUT" | jq -r '.cwd')
 
 # Skip empty or very short prompts
 if [ ${#PROMPT} -lt 10 ]; then
+  HOOK_OUTCOME="skipped"
+  HOOK_OUTCOME_MESSAGE="Prompt too short"
+  hook_obs_event "info" "skip_reason" "skipped" --message "prompt shorter than 10 characters" --session-id "$SESSION_ID"
   exit 0
 fi
 
@@ -61,16 +102,31 @@ fi
 # This provides Haiku with context about what Claude was working on
 CONTEXT=""
 if [ -f "$TRANSCRIPT" ]; then
+  context_started="$(hook_now_ms)"
   ERR_FILE=$(mktemp)
   CONTEXT=$(python3 "${CLAUDE_PLUGIN_ROOT}/hooks/extract-transcript-context.py" "$TRANSCRIPT" 3000 2>"$ERR_FILE")
-  [ -s "$ERR_FILE" ] && log_activity "[auto-peek] context extraction error: $(cat "$ERR_FILE")"
+  context_exit=$?
+  context_duration=$(( $(hook_now_ms) - context_started ))
+  if [ -s "$ERR_FILE" ]; then
+    hook_log_activity "[auto-peek] context extraction error: $(cat "$ERR_FILE")"
+  fi
+  if [ "$context_exit" -eq 0 ]; then
+    hook_obs_event "debug" "subprocess_exit" "success" \
+      --session-id "$SESSION_ID" \
+      --duration-ms "$context_duration" \
+      --counts-json '{"command":"extract_transcript_context","exit_code":0}'
+  else
+    hook_obs_event "warn" "subprocess_exit" "failure" \
+      --session-id "$SESSION_ID" \
+      --duration-ms "$context_duration" \
+      --counts-json "{\"command\":\"extract_transcript_context\",\"exit_code\":$context_exit}"
+  fi
   rm -f "$ERR_FILE"
 fi
 
 # Create empty MCP config to prevent LSP/MCP overhead
 EMPTY_MCP=$(mktemp)
 echo '{"mcpServers":{}}' > "$EMPTY_MCP"
-trap "rm -f $EMPTY_MCP" EXIT
 
 # Build the Haiku prompt with optional context
 if [ -n "$CONTEXT" ]; then
@@ -103,6 +159,7 @@ fi
 # This is fast because: no MCP, no tools, just prompt/response
 # Use timeout to prevent hook from hanging
 export CLAUDE_SUBPROCESS=1
+keyword_started="$(hook_now_ms)"
 ERR_FILE=$(mktemp)
 KEYWORDS_JSON=$(timeout 15 claude -p \
   --no-session-persistence \
@@ -111,27 +168,52 @@ KEYWORDS_JSON=$(timeout 15 claude -p \
   --mcp-config "$EMPTY_MCP" \
   --strict-mcp-config \
   "$HAIKU_PROMPT" 2>"$ERR_FILE")
-[ -s "$ERR_FILE" ] && log_activity "[auto-peek] keyword extraction error: $(cat "$ERR_FILE")"
+keyword_exit=$?
+keyword_duration=$(( $(hook_now_ms) - keyword_started ))
+if [ -s "$ERR_FILE" ]; then
+  hook_log_activity "[auto-peek] keyword extraction error: $(cat "$ERR_FILE")"
+fi
+if [ "$keyword_exit" -eq 0 ]; then
+  hook_obs_event "info" "subprocess_exit" "success" \
+    --session-id "$SESSION_ID" \
+    --duration-ms "$keyword_duration" \
+    --counts-json '{"command":"haiku_keyword_extract","exit_code":0}'
+else
+  hook_obs_event "warn" "subprocess_exit" "failure" \
+    --session-id "$SESSION_ID" \
+    --duration-ms "$keyword_duration" \
+    --counts-json "{\"command\":\"haiku_keyword_extract\",\"exit_code\":$keyword_exit}"
+fi
 rm -f "$ERR_FILE"
 
 # Parse keywords from Haiku response (handles markdown-wrapped JSON)
 # Haiku may return: {"result": "```json\n{\"keywords\": [...]}\n```"}
 # Use pure jq to strip markdown fences and parse JSON
 # Limit to first 2 keywords, keep as JSON array for parallel search
-RESULT_FIELD=$(echo "$KEYWORDS_JSON" | jq -r '.result // empty' 2>/dev/null)
 KEYWORDS_ARRAY=$(echo "$KEYWORDS_JSON" | jq -c '.result // empty | gsub("```json"; "") | gsub("```"; "") | fromjson | .keywords // [] | .[0:2]' 2>/dev/null)
 KEYWORDS_DISPLAY=$(echo "$KEYWORDS_ARRAY" | jq -r 'join(", ")' 2>/dev/null)
 
 # If no keywords extracted, skip search
 if [ -z "$KEYWORDS_ARRAY" ] || [ "$KEYWORDS_ARRAY" = "null" ] || [ "$KEYWORDS_ARRAY" = "[]" ]; then
+  HOOK_OUTCOME="skipped"
+  HOOK_OUTCOME_MESSAGE="No keywords extracted"
+  hook_obs_event "info" "skip_reason" "skipped" \
+    --session-id "$SESSION_ID" \
+    --message "keyword extraction produced no keywords"
   exit 0
 fi
 
-log_activity "[auto-peek] keywords extracted: $KEYWORDS_DISPLAY"
+KEYWORD_COUNT=$(echo "$KEYWORDS_ARRAY" | jq -r 'length' 2>/dev/null)
+KEYWORD_COUNT="${KEYWORD_COUNT:-0}"
+hook_log_activity "[auto-peek] keywords extracted: $KEYWORDS_DISPLAY"
+hook_obs_event "info" "keyword_extract" "success" \
+  --session-id "$SESSION_ID" \
+  --counts-json "{\"keywords\":$KEYWORD_COUNT}"
 
 # Search with extracted keywords in parallel, exclude seen IDs
 # Each keyword is searched independently and results are merged
 ERR_FILE=$(mktemp)
+search_started="$(hook_now_ms)"
 SEARCH_RESULT=$(python3 "${CLAUDE_PLUGIN_ROOT}/scripts/search-learnings.py" \
   --peek \
   --max-results 2 \
@@ -139,18 +221,39 @@ SEARCH_RESULT=$(python3 "${CLAUDE_PLUGIN_ROOT}/scripts/search-learnings.py" \
   --keywords-json "$KEYWORDS_ARRAY" \
   "$CWD" 2>"$ERR_FILE")
 SEARCH_EXIT=$?
-[ -s "$ERR_FILE" ] && log_activity "[auto-peek] search error: $(cat "$ERR_FILE")"
+search_duration=$(( $(hook_now_ms) - search_started ))
+if [ -s "$ERR_FILE" ]; then
+  hook_log_activity "[auto-peek] search error: $(cat "$ERR_FILE")"
+fi
+if [ "$SEARCH_EXIT" -eq 0 ]; then
+  hook_obs_event "info" "subprocess_exit" "success" \
+    --session-id "$SESSION_ID" \
+    --duration-ms "$search_duration" \
+    --counts-json '{"command":"search_learnings","exit_code":0}'
+else
+  hook_obs_event "error" "subprocess_exit" "failure" \
+    --session-id "$SESSION_ID" \
+    --duration-ms "$search_duration" \
+    --counts-json "{\"command\":\"search_learnings\",\"exit_code\":$SEARCH_EXIT}"
+fi
 rm -f "$ERR_FILE"
 
 # Check if we got results
 if [ $SEARCH_EXIT -ne 0 ]; then
+  HOOK_OUTCOME="error"
+  HOOK_OUTCOME_MESSAGE="search-learnings.py failed"
   echo "[auto-peek] search failed (check ~/.claude/plugins/compound-learning/activity.log)"
   exit 0
 fi
 
 STATUS=$(echo "$SEARCH_RESULT" | jq -r '.status' 2>/dev/null)
 if [ "$STATUS" != "found" ]; then
-  log_activity "[auto-peek] no results for: $KEYWORDS_DISPLAY"
+  HOOK_OUTCOME="skipped"
+  HOOK_OUTCOME_MESSAGE="No relevant learnings found"
+  hook_obs_event "info" "skip_reason" "skipped" \
+    --session-id "$SESSION_ID" \
+    --message "search status $STATUS"
+  hook_log_activity "[auto-peek] no results for: $KEYWORDS_DISPLAY"
   echo "[auto-peek] no learnings for: $KEYWORDS_DISPLAY"
   exit 0
 fi
@@ -159,13 +262,18 @@ echo "$SEARCH_RESULT" | jq -r '.learnings[].id' 2>/dev/null >> "$SESSION_FILE"
 
 # Format compact output for Claude's context
 COUNT=$(echo "$SEARCH_RESULT" | jq -r '.count' 2>/dev/null)
+RESULT_COUNT="${COUNT:-0}"
 echo "[auto-peek] $COUNT learning(s) found for: $KEYWORDS_DISPLAY"
 
 # Log search results with details
-log_activity "SEARCH: query='$KEYWORDS_DISPLAY' count=$COUNT"
+hook_log_activity "SEARCH: query='$KEYWORDS_DISPLAY' count=$COUNT"
 echo "$SEARCH_RESULT" | jq -r '.learnings[] | "  file: \(.metadata.file_path | split("/") | .[-1])  title: \(.metadata.summary // .document | split("\n")[0] | .[0:100])  id: \(.id)"' 2>/dev/null | while read -r line; do
-  log_activity "  RESULT: $line"
+  hook_log_activity "  RESULT: $line"
 done
+
+hook_obs_event "info" "search_result" "found" \
+  --session-id "$SESSION_ID" \
+  --counts-json "{\"result_count\":$RESULT_COUNT}"
 
 # Show compact summary: filename and first line of summary/title
 echo "$SEARCH_RESULT" | jq -r '.learnings[] | "  -> " + (.metadata.file_path | split("/") | .[-1]) + ": " + (.metadata.summary // .document | split("\n")[0] | .[0:80])' 2>/dev/null

--- a/plugins/compound-learning/hooks/extract-learnings.sh
+++ b/plugins/compound-learning/hooks/extract-learnings.sh
@@ -3,36 +3,89 @@
 # Auto-extract learnings from Claude sessions via hooks
 # Triggered by PreCompact and SessionEnd hooks
 
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$HOOK_DIR/observability.sh" || exit 0
+
+hook_log_init "extract-learnings"
+SESSION_ID="${CLAUDE_SESSION_ID:-}"
+HOOK_OUTCOME="success"
+HOOK_OUTCOME_MESSAGE=""
+FILE_COUNT=0
+INDEXED_COUNT=0
+INDEX_FAILED_COUNT=0
+
+OUTPUT_FILE=""
+BEFORE_FILES=""
+AFTER_FILES=""
+
+extract_finalize() {
+  [ -n "$OUTPUT_FILE" ] && [ -f "$OUTPUT_FILE" ] && rm -f "$OUTPUT_FILE"
+  [ -n "$BEFORE_FILES" ] && [ -f "$BEFORE_FILES" ] && rm -f "$BEFORE_FILES"
+  [ -n "$AFTER_FILES" ] && [ -f "$AFTER_FILES" ] && rm -f "$AFTER_FILES"
+
+  local duration_ms
+  duration_ms="$(hook_elapsed_ms)"
+  local level="info"
+  case "$HOOK_OUTCOME" in
+    success) level="info" ;;
+    skipped) level="info" ;;
+    error) level="error" ;;
+    *) level="warn" ;;
+  esac
+
+  hook_obs_event "$level" "hook_end" "$HOOK_OUTCOME" \
+    --session-id "$SESSION_ID" \
+    --duration-ms "$duration_ms" \
+    --message "$HOOK_OUTCOME_MESSAGE" \
+    --counts-json "{\"generated\":$FILE_COUNT,\"indexed\":$INDEXED_COUNT,\"index_failed\":$INDEX_FAILED_COUNT}"
+}
+trap extract_finalize EXIT
+
+hook_obs_event "info" "hook_start" "start" --session-id "$SESSION_ID"
+
 # Bail if plugin root not set
 if [ -z "$CLAUDE_PLUGIN_ROOT" ]; then
+  HOOK_OUTCOME="skipped"
+  HOOK_OUTCOME_MESSAGE="CLAUDE_PLUGIN_ROOT not set"
+  hook_obs_event "info" "skip_reason" "skipped" --session-id "$SESSION_ID" --message "plugin root not set"
   exit 0
 fi
 
-# Setup logging
-LOG_DIR="$HOME/.claude/plugins/compound-learning"
-mkdir -p "$LOG_DIR"
-LOG_FILE="$LOG_DIR/activity.log"
-
-log_activity() {
-  echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" >> "$LOG_FILE"
-}
-
 # Skip all hooks for subprocess calls (prevents recursion)
 if [ -n "$CLAUDE_SUBPROCESS" ]; then
+  HOOK_OUTCOME="skipped"
+  HOOK_OUTCOME_MESSAGE="Skipping in subprocess context"
+  hook_obs_event "info" "skip_reason" "skipped" --session-id "$SESSION_ID" --message "CLAUDE_SUBPROCESS is set"
   exit 0
 fi
 
 # Source worktree-aware repo root resolution
-source "${CLAUDE_PLUGIN_ROOT}/lib/git-worktree.sh" || { log_activity "[extract-learnings] WARN: could not source git-worktree.sh, using CWD as REPO_ROOT"; }
+source "${CLAUDE_PLUGIN_ROOT}/lib/git-worktree.sh" || {
+  hook_log_activity "[extract-learnings] WARN: could not source git-worktree.sh, using CWD as REPO_ROOT"
+  hook_obs_event "warn" "repo_root_resolve" "fallback" --session-id "$SESSION_ID" --message "git-worktree.sh source failed"
+}
 
 # Read hook input from stdin
 INPUT=$(cat)
-SESSION_ID=$(echo "$INPUT" | jq -r '.session_id')
-TRANSCRIPT=$(echo "$INPUT" | jq -r '.transcript_path')
-CWD=$(echo "$INPUT" | jq -r '.cwd')
+SESSION_FROM_INPUT=$(echo "$INPUT" | jq -r '.session_id // empty')
+if [ -n "$SESSION_FROM_INPUT" ] && [ "$SESSION_FROM_INPUT" != "null" ]; then
+  SESSION_ID="$SESSION_FROM_INPUT"
+fi
+TRANSCRIPT=$(echo "$INPUT" | jq -r '.transcript_path // empty')
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
+
+if [ -z "$TRANSCRIPT" ] || [ "$TRANSCRIPT" = "null" ]; then
+  HOOK_OUTCOME="skipped"
+  HOOK_OUTCOME_MESSAGE="No transcript path provided"
+  hook_obs_event "info" "skip_reason" "skipped" --session-id "$SESSION_ID" --message "missing transcript path"
+  exit 0
+fi
 
 # Resolve real repo root (handles worktrees)
-REPO_ROOT=$(resolve_repo_root "$CWD")
+REPO_ROOT="$CWD"
+if command -v resolve_repo_root >/dev/null 2>&1; then
+  REPO_ROOT=$(resolve_repo_root "$CWD")
+fi
 REPO_ROOT="${REPO_ROOT:-$CWD}"
 
 # Expand ~ in transcript path
@@ -41,17 +94,40 @@ TRANSCRIPT="${TRANSCRIPT/#\~/$HOME}"
 # Skip tiny transcripts (trivial sessions)
 LINES=$(wc -l < "$TRANSCRIPT" 2>/dev/null || echo "0")
 if [ "$LINES" -lt 20 ]; then
+  HOOK_OUTCOME="skipped"
+  HOOK_OUTCOME_MESSAGE="Transcript too short"
+  hook_obs_event "info" "skip_reason" "skipped" --session-id "$SESSION_ID" --message "transcript line count < 20"
   exit 0
 fi
 
 # Extract just user/assistant messages (skip tool calls, file snapshots, metadata)
 # Limit to ~80KB to fit context window with prompt overhead
 MAX_BYTES=80000
+extract_started="$(hook_now_ms)"
 ERR_FILE=$(mktemp)
 TRANSCRIPT_CONTENT=$(python3 "${CLAUDE_PLUGIN_ROOT}/hooks/extract-transcript-messages.py" "$TRANSCRIPT" "$MAX_BYTES" 2>"$ERR_FILE")
-[ -s "$ERR_FILE" ] && log_activity "[extract-learnings] parse error: $(cat "$ERR_FILE")"
+extract_exit=$?
+extract_duration=$(( $(hook_now_ms) - extract_started ))
+if [ -s "$ERR_FILE" ]; then
+  hook_log_activity "[extract-learnings] parse error: $(cat "$ERR_FILE")"
+fi
+if [ "$extract_exit" -eq 0 ]; then
+  hook_obs_event "info" "subprocess_exit" "success" \
+    --session-id "$SESSION_ID" \
+    --duration-ms "$extract_duration" \
+    --counts-json '{"command":"extract_transcript_messages","exit_code":0}'
+else
+  hook_obs_event "warn" "subprocess_exit" "failure" \
+    --session-id "$SESSION_ID" \
+    --duration-ms "$extract_duration" \
+    --counts-json "{\"command\":\"extract_transcript_messages\",\"exit_code\":$extract_exit}"
+fi
 rm -f "$ERR_FILE"
+
 if [ -z "$TRANSCRIPT_CONTENT" ]; then
+  HOOK_OUTCOME="skipped"
+  HOOK_OUTCOME_MESSAGE="No transcript content extracted"
+  hook_obs_event "info" "skip_reason" "skipped" --session-id "$SESSION_ID" --message "transcript extraction returned empty content"
   exit 0
 fi
 
@@ -67,11 +143,13 @@ BEFORE_FILES=$(mktemp)
 AFTER_FILES=$(mktemp)
 find "$GLOBAL_DIR" "$REPO_DIR" -type f -name "*.md" 2>/dev/null | sort > "$BEFORE_FILES"
 
-trap "rm -f $OUTPUT_FILE $BEFORE_FILES $AFTER_FILES" EXIT
-
-log_activity "EXTRACT_START: session=$SESSION_ID lines=$LINES"
+hook_log_activity "EXTRACT_START: session=$SESSION_ID lines=$LINES"
+hook_obs_event "info" "extract_start" "start" \
+  --session-id "$SESSION_ID" \
+  --counts-json "{\"transcript_lines\":$LINES}"
 
 # Use heredoc to pass prompt via stdin (avoids temp files and arg size limits)
+claude_started="$(hook_now_ms)"
 CLAUDE_SUBPROCESS=1 claude -p --no-session-persistence \
   --permission-mode bypassPermissions \
   --add-dir "$HOME/.projects" "$REPO_ROOT/.projects" \
@@ -93,13 +171,28 @@ If nothing worth extracting, just output 'none'.
 ${TRANSCRIPT_CONTENT}
 </transcript>
 PROMPT_END
+claude_exit=$?
+claude_duration=$(( $(hook_now_ms) - claude_started ))
+
+if [ "$claude_exit" -eq 0 ]; then
+  hook_obs_event "info" "subprocess_exit" "success" \
+    --session-id "$SESSION_ID" \
+    --duration-ms "$claude_duration" \
+    --counts-json '{"command":"claude_extract","exit_code":0}'
+else
+  HOOK_OUTCOME="error"
+  HOOK_OUTCOME_MESSAGE="claude extraction command failed"
+  hook_obs_event "error" "subprocess_exit" "failure" \
+    --session-id "$SESSION_ID" \
+    --duration-ms "$claude_duration" \
+    --counts-json "{\"command\":\"claude_extract\",\"exit_code\":$claude_exit}"
+fi
 
 # Detect new files via filesystem diff
 find "$GLOBAL_DIR" "$REPO_DIR" -type f -name "*.md" 2>/dev/null | sort > "$AFTER_FILES"
 NEW_FILES=$(comm -13 "$BEFORE_FILES" "$AFTER_FILES")
 
 INDEX_SCRIPT="${CLAUDE_PLUGIN_ROOT}/skills/index-learnings/index-learnings.py"
-FILE_COUNT=0
 
 while IFS= read -r file; do
   [ -z "$file" ] && continue
@@ -110,16 +203,41 @@ while IFS= read -r file; do
   TITLE=$(grep -m1 "^# " "$file" 2>/dev/null | sed 's/^# //' | tr -d '\n\r')
   [ -z "$TITLE" ] && TITLE="$FILENAME"
 
-  log_activity "  GENERATED: file=$FILENAME title=\"$TITLE\""
+  hook_log_activity "  GENERATED: file=$FILENAME title=\"$TITLE\""
 
   # Index the newly created file into SQLite (non-fatal if unavailable)
   if [ -f "$INDEX_SCRIPT" ]; then
-    CLAUDE_PLUGIN_ROOT="$CLAUDE_PLUGIN_ROOT" python3 "$INDEX_SCRIPT" --file "$file" >> "$LOG_FILE" 2>&1 \
-      && log_activity "  INDEXED: $FILENAME" \
-      || log_activity "  INDEX_SKIP: indexing failed for $FILENAME"
+    index_started="$(hook_now_ms)"
+    CLAUDE_PLUGIN_ROOT="$CLAUDE_PLUGIN_ROOT" python3 "$INDEX_SCRIPT" --file "$file" >> "$HOOK_ACTIVITY_LOG" 2>&1
+    index_exit=$?
+    index_duration=$(( $(hook_now_ms) - index_started ))
+    if [ "$index_exit" -eq 0 ]; then
+      INDEXED_COUNT=$((INDEXED_COUNT + 1))
+      hook_log_activity "  INDEXED: $FILENAME"
+      hook_obs_event "info" "subprocess_exit" "success" \
+        --session-id "$SESSION_ID" \
+        --duration-ms "$index_duration" \
+        --counts-json "{\"command\":\"index_single_file\",\"exit_code\":0}"
+    else
+      INDEX_FAILED_COUNT=$((INDEX_FAILED_COUNT + 1))
+      hook_log_activity "  INDEX_SKIP: indexing failed for $FILENAME"
+      hook_obs_event "warn" "subprocess_exit" "failure" \
+        --session-id "$SESSION_ID" \
+        --duration-ms "$index_duration" \
+        --counts-json "{\"command\":\"index_single_file\",\"exit_code\":$index_exit}"
+    fi
   fi
 done <<< "$NEW_FILES"
 
-log_activity "EXTRACT_END: session=$SESSION_ID generated=$FILE_COUNT"
+hook_log_activity "EXTRACT_END: session=$SESSION_ID generated=$FILE_COUNT"
+hook_obs_event "info" "extract_complete" "success" \
+  --session-id "$SESSION_ID" \
+  --counts-json "{\"generated\":$FILE_COUNT,\"indexed\":$INDEXED_COUNT,\"index_failed\":$INDEX_FAILED_COUNT}"
+
+if [ "$FILE_COUNT" -eq 0 ] && [ "$HOOK_OUTCOME" = "success" ]; then
+  HOOK_OUTCOME_MESSAGE="No new learnings generated"
+else
+  HOOK_OUTCOME_MESSAGE="Generated $FILE_COUNT learning file(s)"
+fi
 
 exit 0

--- a/plugins/compound-learning/hooks/observability.sh
+++ b/plugins/compound-learning/hooks/observability.sh
@@ -1,0 +1,250 @@
+#!/bin/bash
+
+# Shared logging + structured observability helpers for compound-learning hooks.
+
+hook_now_ms() {
+  local ms
+  ms=$(date +%s%3N 2>/dev/null)
+  if [ -n "$ms" ]; then
+    echo "$ms"
+  else
+    python3 - <<'PY'
+import time
+print(int(time.time() * 1000))
+PY
+  fi
+}
+
+hook_iso_utc() {
+  date -u '+%Y-%m-%dT%H:%M:%SZ'
+}
+
+hook_normalize_level() {
+  case "${1:-info}" in
+    debug) echo "debug" ;;
+    info) echo "info" ;;
+    warning|warn) echo "warn" ;;
+    error) echo "error" ;;
+    *) echo "info" ;;
+  esac
+}
+
+hook_level_rank() {
+  case "$(hook_normalize_level "$1")" in
+    debug) echo 10 ;;
+    info) echo 20 ;;
+    warn) echo 30 ;;
+    error) echo 40 ;;
+    *) echo 20 ;;
+  esac
+}
+
+hook_expand_home() {
+  local raw="$1"
+  echo "${raw//\$\{HOME\}/$HOME}"
+}
+
+hook_make_correlation_id() {
+  if [ -n "${LEARNINGS_OBS_CORRELATION_ID:-}" ]; then
+    echo "${LEARNINGS_OBS_CORRELATION_ID}"
+    return
+  fi
+  if [ -f /proc/sys/kernel/random/uuid ]; then
+    tr -d '-' < /proc/sys/kernel/random/uuid
+    return
+  fi
+  python3 - <<'PY'
+import uuid
+print(uuid.uuid4().hex)
+PY
+}
+
+hook_json_or_null() {
+  local raw="$1"
+  if [ -z "$raw" ]; then
+    echo "null"
+    return
+  fi
+  if echo "$raw" | jq -e . >/dev/null 2>&1; then
+    echo "$raw"
+  else
+    echo "null"
+  fi
+}
+
+hook_log_init() {
+  HOOK_NAME="${1:-unknown}"
+  HOOK_LOG_DIR="$HOME/.claude/plugins/compound-learning"
+  if ! mkdir -p "$HOOK_LOG_DIR" 2>/dev/null; then
+    HOOK_LOG_DIR="$HOME/.claude/plugins/compound-learning-logs"
+    if ! mkdir -p "$HOOK_LOG_DIR" 2>/dev/null; then
+      HOOK_LOG_DIR="/tmp/compound-learning-logs"
+      mkdir -p "$HOOK_LOG_DIR" 2>/dev/null || true
+    fi
+  fi
+  HOOK_ACTIVITY_LOG="$HOOK_LOG_DIR/activity.log"
+
+  local config_file=""
+  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
+    config_file="${CLAUDE_PLUGIN_ROOT}/.claude-plugin/config.json"
+  else
+    local hook_dir
+    hook_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    config_file="$(cd "$hook_dir/.." && pwd)/.claude-plugin/config.json"
+  fi
+
+  local cfg_enabled=""
+  local cfg_level=""
+  local cfg_log_path=""
+  if [ -f "$config_file" ] && command -v jq >/dev/null 2>&1; then
+    cfg_enabled=$(jq -r '.observability.enabled // empty' "$config_file" 2>/dev/null)
+    cfg_level=$(jq -r '.observability.level // empty' "$config_file" 2>/dev/null)
+    cfg_log_path=$(jq -r '.observability.logPath // empty' "$config_file" 2>/dev/null)
+  fi
+
+  local enabled_raw="${LEARNINGS_OBS_ENABLED:-$cfg_enabled}"
+  case "${enabled_raw,,}" in
+    1|true|yes|on) HOOK_OBS_ENABLED="1" ;;
+    0|false|no|off) HOOK_OBS_ENABLED="0" ;;
+    *) HOOK_OBS_ENABLED="0" ;;
+  esac
+
+  HOOK_OBS_LEVEL="$(hook_normalize_level "${LEARNINGS_OBS_LEVEL:-$cfg_level}")"
+
+  local log_path_raw="${LEARNINGS_OBS_LOG_PATH:-$cfg_log_path}"
+  if [ -z "$log_path_raw" ]; then
+    log_path_raw="$HOOK_LOG_DIR/observability.jsonl"
+  fi
+  HOOK_OBS_LOG_PATH="$(hook_expand_home "$log_path_raw")"
+
+  HOOK_CORRELATION_ID="$(hook_make_correlation_id)"
+  HOOK_START_MS="$(hook_now_ms)"
+}
+
+hook_log_activity() {
+  local message="$1"
+  printf '[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$message" >> "$HOOK_ACTIVITY_LOG"
+}
+
+hook_obs_level_allows() {
+  local requested
+  local minimum
+  requested="$(hook_level_rank "$1")"
+  minimum="$(hook_level_rank "${HOOK_OBS_LEVEL:-info}")"
+  [ "$requested" -ge "$minimum" ]
+}
+
+hook_safe_append() {
+  local line="$1"
+  mkdir -p "$(dirname "$HOOK_OBS_LOG_PATH")" 2>/dev/null || return 0
+  if command -v flock >/dev/null 2>&1; then
+    {
+      flock -x 200
+      printf '%s\n' "$line" >> "$HOOK_OBS_LOG_PATH" 2>/dev/null
+    } 200>>"${HOOK_OBS_LOG_PATH}.lock"
+  else
+    printf '%s\n' "$line" >> "$HOOK_OBS_LOG_PATH" 2>/dev/null
+  fi
+}
+
+hook_obs_event() {
+  local level="$1"
+  local operation="$2"
+  local status="$3"
+  shift 3
+
+  [ "${HOOK_OBS_ENABLED:-0}" = "1" ] || return 0
+  hook_obs_level_allows "$level" || return 0
+
+  local message=""
+  local duration_ms=""
+  local session_id=""
+  local correlation_id="${HOOK_CORRELATION_ID:-}"
+  local counts_json="null"
+  local error_json="null"
+  local extra_json="null"
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --message)
+        message="$2"
+        shift 2
+        ;;
+      --duration-ms)
+        duration_ms="$2"
+        shift 2
+        ;;
+      --session-id)
+        session_id="$2"
+        shift 2
+        ;;
+      --correlation-id)
+        correlation_id="$2"
+        shift 2
+        ;;
+      --counts-json)
+        counts_json="$(hook_json_or_null "$2")"
+        shift 2
+        ;;
+      --error-json)
+        error_json="$(hook_json_or_null "$2")"
+        shift 2
+        ;;
+      --extra-json)
+        extra_json="$(hook_json_or_null "$2")"
+        shift 2
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+
+  local duration_json="null"
+  if [ -n "$duration_ms" ]; then
+    duration_json="$duration_ms"
+  fi
+
+  local event
+  event=$(jq -cn \
+    --arg timestamp "$(hook_iso_utc)" \
+    --arg level "$(hook_normalize_level "$level")" \
+    --arg component "hook" \
+    --arg hook "${HOOK_NAME:-unknown}" \
+    --arg operation "$operation" \
+    --arg status "$status" \
+    --arg message "$message" \
+    --arg session_id "$session_id" \
+    --arg correlation_id "$correlation_id" \
+    --argjson duration_ms "$duration_json" \
+    --argjson counts "$counts_json" \
+    --argjson error "$error_json" \
+    --argjson extra "$extra_json" \
+    '
+    {
+      timestamp: $timestamp,
+      level: $level,
+      component: $component,
+      hook: $hook,
+      operation: $operation,
+      status: $status
+    }
+    + (if $duration_ms == null then {} else {duration_ms: $duration_ms} end)
+    + (if ($message | length) == 0 then {} else {message: $message} end)
+    + (if ($session_id | length) == 0 then {} else {session_id: $session_id} end)
+    + (if ($correlation_id | length) == 0 then {} else {correlation_id: $correlation_id} end)
+    + (if $counts == null then {} else {counts: $counts} end)
+    + (if $error == null then {} else {error: $error} end)
+    + (if $extra == null then {} else $extra end)
+    ' 2>/dev/null)
+
+  [ -n "$event" ] || return 0
+  hook_safe_append "$event"
+}
+
+hook_elapsed_ms() {
+  local end_ms
+  end_ms="$(hook_now_ms)"
+  local start_ms="${HOOK_START_MS:-$end_ms}"
+  echo $((end_ms - start_ms))
+}

--- a/plugins/compound-learning/hooks/setup.sh
+++ b/plugins/compound-learning/hooks/setup.sh
@@ -5,13 +5,33 @@
 # Idempotent: skips pip if all packages already importable
 # Exits 0 always to avoid blocking session start
 
-LOG_DIR="$HOME/.claude/plugins/compound-learning"
-mkdir -p "$LOG_DIR"
-LOG_FILE="$LOG_DIR/activity.log"
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$HOOK_DIR/observability.sh" || exit 0
 
-log_activity() {
-  echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" >> "$LOG_FILE"
+hook_log_init "setup"
+SESSION_ID="${CLAUDE_SESSION_ID:-}"
+HOOK_OUTCOME="success"
+HOOK_OUTCOME_MESSAGE=""
+
+setup_hook_finalize() {
+  local duration_ms
+  duration_ms="$(hook_elapsed_ms)"
+  local level="info"
+  case "$HOOK_OUTCOME" in
+    success) level="info" ;;
+    skipped) level="info" ;;
+    error) level="error" ;;
+    *) level="warn" ;;
+  esac
+
+  hook_obs_event "$level" "hook_end" "$HOOK_OUTCOME" \
+    --duration-ms "$duration_ms" \
+    --session-id "$SESSION_ID" \
+    --message "$HOOK_OUTCOME_MESSAGE"
 }
+trap setup_hook_finalize EXIT
+
+hook_obs_event "info" "hook_start" "start" --session-id "$SESSION_ID"
 
 # Quick check: can we import all required packages?
 if python3 -c "
@@ -20,16 +40,43 @@ for pkg in ['pysqlite3', 'sqlite_vec', 'sentence_transformers']:
     if importlib.util.find_spec(pkg) is None:
         sys.exit(1)
 " 2>/dev/null; then
+  hook_obs_event "info" "dependency_check" "success" \
+    --session-id "$SESSION_ID" \
+    --counts-json '{"missing_packages":0}'
+  hook_obs_event "info" "subprocess_exit" "success" \
+    --session-id "$SESSION_ID" \
+    --counts-json '{"command":"python_import_check","exit_code":0}'
+  HOOK_OUTCOME="skipped"
+  HOOK_OUTCOME_MESSAGE="Dependencies already installed"
+  hook_obs_event "info" "skip_reason" "skipped" \
+    --session-id "$SESSION_ID" \
+    --message "dependencies already installed"
   exit 0
 fi
 
-log_activity "[setup] Missing Python dependencies, installing..."
+hook_obs_event "warn" "subprocess_exit" "failure" \
+  --session-id "$SESSION_ID" \
+  --counts-json '{"command":"python_import_check","exit_code":1}'
+hook_obs_event "info" "dependency_check" "missing" \
+  --session-id "$SESSION_ID"
+hook_log_activity "[setup] Missing Python dependencies, installing..."
 
 # Install all required packages quietly
-if pip install --quiet pysqlite3-binary sqlite-vec sentence-transformers 2>>"$LOG_FILE"; then
-  log_activity "[setup] Python dependencies installed successfully"
+if pip install --quiet pysqlite3-binary sqlite-vec sentence-transformers 2>>"$HOOK_ACTIVITY_LOG"; then
+  hook_log_activity "[setup] Python dependencies installed successfully"
+  hook_obs_event "info" "subprocess_exit" "success" \
+    --session-id "$SESSION_ID" \
+    --counts-json '{"command":"pip_install","exit_code":0}'
+  HOOK_OUTCOME="success"
+  HOOK_OUTCOME_MESSAGE="Dependencies installed successfully"
 else
-  log_activity "[setup] pip install failed (exit $?), plugin may not work correctly"
+  pip_exit=$?
+  hook_log_activity "[setup] pip install failed (exit $pip_exit), plugin may not work correctly"
+  hook_obs_event "error" "subprocess_exit" "failure" \
+    --session-id "$SESSION_ID" \
+    --counts-json "{\"command\":\"pip_install\",\"exit_code\":$pip_exit}"
+  HOOK_OUTCOME="error"
+  HOOK_OUTCOME_MESSAGE="pip install failed (exit $pip_exit)"
 fi
 
 exit 0

--- a/plugins/compound-learning/lib/db.py
+++ b/plugins/compound-learning/lib/db.py
@@ -9,7 +9,7 @@ import os
 import sys
 import threading
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Mapping, Optional
 
 try:
     import sqlite3
@@ -28,6 +28,41 @@ except AttributeError:
 
 _model = None
 _model_lock = threading.Lock()
+
+
+import lib.observability as observability
+
+
+def _parse_bool(value: Any) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {'1', 'true', 'yes', 'on'}:
+            return True
+        if normalized in {'0', 'false', 'no', 'off'}:
+            return False
+    return None
+
+
+def _normalize_level(value: Any) -> str:
+    level = str(value or 'info').strip().lower()
+    if level == 'warning':
+        level = 'warn'
+    if level not in {'debug', 'info', 'warn', 'error'}:
+        return 'info'
+    return level
+
+
+def _db_logger(
+    config: Optional[Mapping[str, Any]],
+    **fields: Any,
+) -> observability.StructuredLogger:
+    return observability.get_logger('db', config, **fields)
 
 
 def load_config() -> Dict[str, Any]:
@@ -53,6 +88,11 @@ def load_config() -> Dict[str, Any]:
             'outdatedKeywords': ['temporary', 'workaround', 'deprecated', 'todo', 'fixme',
                                  'hack', 'remove later', 'obsolete'],
         },
+        'observability': {
+            'enabled': False,
+            'level': 'info',
+            'logPath': os.path.join(home, '.claude', 'plugins', 'compound-learning', 'observability.jsonl'),
+        },
     }
 
     # Determine plugin root for config file location
@@ -77,6 +117,9 @@ def load_config() -> Dict[str, Any]:
     env_db_path = os.environ.get('SQLITE_DB_PATH')
     env_global_dir = os.environ.get('LEARNINGS_GLOBAL_DIR')
     env_repo_path = os.environ.get('LEARNINGS_REPO_SEARCH_PATH')
+    env_obs_enabled = os.environ.get('LEARNINGS_OBS_ENABLED')
+    env_obs_level = os.environ.get('LEARNINGS_OBS_LEVEL')
+    env_obs_log_path = os.environ.get('LEARNINGS_OBS_LOG_PATH')
 
     result = _deep_merge(defaults, file_config)
 
@@ -86,6 +129,14 @@ def load_config() -> Dict[str, Any]:
         result['learnings']['globalDir'] = os.path.expanduser(env_global_dir)
     if env_repo_path:
         result['learnings']['repoSearchPath'] = os.path.expanduser(env_repo_path)
+    if env_obs_enabled is not None:
+        parsed = _parse_bool(env_obs_enabled)
+        if parsed is not None:
+            result['observability']['enabled'] = parsed
+    if env_obs_level:
+        result['observability']['level'] = _normalize_level(env_obs_level)
+    if env_obs_log_path:
+        result['observability']['logPath'] = os.path.expanduser(env_obs_log_path)
 
     return result
 
@@ -115,59 +166,135 @@ def get_connection(config: Dict[str, Any]) -> sqlite3.Connection:
     import sqlite_vec
 
     db_path = config['sqlite']['dbPath']
-    os.makedirs(os.path.dirname(db_path), exist_ok=True)
+    logger = _db_logger(config, db_path=db_path)
+    started = observability.now_perf()
+    logger.emit('connection_open', 'start', level='debug')
 
-    conn = sqlite3.connect(db_path)
-    conn.row_factory = sqlite3.Row
+    try:
+        os.makedirs(os.path.dirname(db_path), exist_ok=True)
 
-    conn.enable_load_extension(True)
-    sqlite_vec.load(conn)
-    conn.enable_load_extension(False)
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
 
-    _create_schema(conn)
-    return conn
+        conn.enable_load_extension(True)
+        sqlite_vec.load(conn)
+        conn.enable_load_extension(False)
 
-
-def _create_schema(conn: sqlite3.Connection) -> None:
-    conn.executescript("""
-        CREATE TABLE IF NOT EXISTS learnings (
-            id TEXT PRIMARY KEY,
-            content TEXT NOT NULL,
-            scope TEXT NOT NULL,
-            repo TEXT NOT NULL DEFAULT '',
-            file_path TEXT NOT NULL,
-            topic TEXT NOT NULL DEFAULT 'other',
-            keywords TEXT NOT NULL DEFAULT '',
-            created_at TEXT NOT NULL
-        );
-
-        CREATE VIRTUAL TABLE IF NOT EXISTS vec_learnings USING vec0(
-            id TEXT PRIMARY KEY,
-            embedding float[384]
-        );
-
-        CREATE VIRTUAL TABLE IF NOT EXISTS fts_learnings USING fts5(
-            id UNINDEXED,
-            content,
-            tokenize='porter unicode61'
-        );
-    """)
-    conn.commit()
+        _create_schema(conn, logger=logger)
+        logger.emit(
+            'connection_open',
+            'success',
+            duration_ms=observability.elapsed_ms(started),
+        )
+        return conn
+    except Exception as exc:
+        logger.emit(
+            'connection_open',
+            'error',
+            level='error',
+            duration_ms=observability.elapsed_ms(started),
+            error=exc,
+        )
+        raise
 
 
-def get_embedding(text: str):
+def _create_schema(
+    conn: sqlite3.Connection,
+    logger: observability.StructuredLogger | None = None,
+) -> None:
+    started = observability.now_perf()
+    if logger:
+        logger.emit('schema_init', 'start', level='debug')
+    try:
+        conn.executescript("""
+            CREATE TABLE IF NOT EXISTS learnings (
+                id TEXT PRIMARY KEY,
+                content TEXT NOT NULL,
+                scope TEXT NOT NULL,
+                repo TEXT NOT NULL DEFAULT '',
+                file_path TEXT NOT NULL,
+                topic TEXT NOT NULL DEFAULT 'other',
+                keywords TEXT NOT NULL DEFAULT '',
+                created_at TEXT NOT NULL
+            );
+
+            CREATE VIRTUAL TABLE IF NOT EXISTS vec_learnings USING vec0(
+                id TEXT PRIMARY KEY,
+                embedding float[384]
+            );
+
+            CREATE VIRTUAL TABLE IF NOT EXISTS fts_learnings USING fts5(
+                id UNINDEXED,
+                content,
+                tokenize='porter unicode61'
+            );
+        """)
+        conn.commit()
+        if logger:
+            logger.emit(
+                'schema_init',
+                'success',
+                duration_ms=observability.elapsed_ms(started),
+            )
+    except Exception as exc:
+        if logger:
+            logger.emit(
+                'schema_init',
+                'error',
+                level='error',
+                duration_ms=observability.elapsed_ms(started),
+                error=exc,
+            )
+        raise
+
+
+def get_embedding(text: str, config: Optional[Dict[str, Any]] = None):
     """Lazy-load sentence-transformers model and return embedding as list."""
     global _model
+    logger = _db_logger(config, text_length=len(text))
+    encode_started = observability.now_perf()
+
     with _model_lock:
         if _model is None:
             model_cache = os.path.expanduser(
                 '~/.cache/huggingface/hub/models--sentence-transformers--all-MiniLM-L6-v2'
             )
+            load_started = observability.now_perf()
+            logger.emit(
+                'embedding_model_load',
+                'start',
+                level='debug',
+                model='all-MiniLM-L6-v2',
+            )
             if not os.path.exists(model_cache):
                 print("Downloading embedding model (one-time, ~80MB)...", file=sys.stderr)
             from sentence_transformers import SentenceTransformer
             _model = SentenceTransformer('all-MiniLM-L6-v2')
-    return _model.encode(text, normalize_embeddings=True).tolist()
+            logger.emit(
+                'embedding_model_load',
+                'success',
+                duration_ms=observability.elapsed_ms(load_started),
+                model='all-MiniLM-L6-v2',
+            )
+    try:
+        embedding = _model.encode(text, normalize_embeddings=True)
+        logger.emit(
+            'embedding_encode',
+            'success',
+            level='debug',
+            duration_ms=observability.elapsed_ms(encode_started),
+            counts={'dimensions': len(embedding)},
+        )
+        return embedding.tolist()
+    except Exception as exc:
+        logger.emit(
+            'embedding_encode',
+            'error',
+            level='error',
+            duration_ms=observability.elapsed_ms(encode_started),
+            error=exc,
+        )
+        raise
 
 
 def upsert_document(
@@ -175,52 +302,106 @@ def upsert_document(
     doc_id: str,
     content: str,
     metadata: Dict[str, Any],
+    config: Optional[Dict[str, Any]] = None,
 ) -> None:
     """Atomic upsert into learnings + vec_learnings + fts_learnings."""
     from datetime import datetime, timezone
 
-    embedding = get_embedding(content)
-    created_at = metadata.get('created_at', datetime.now(timezone.utc).isoformat())
-
-    # Delete-then-insert strategy (virtual tables don't support ON CONFLICT cleanly)
-    delete_document(conn, doc_id)
-
-    conn.execute(
-        """INSERT INTO learnings (id, content, scope, repo, file_path, topic, keywords, created_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
-        (
-            doc_id,
-            content,
-            metadata.get('scope', 'global'),
-            metadata.get('repo', ''),
-            metadata.get('file_path', ''),
-            metadata.get('topic', 'other'),
-            metadata.get('keywords', ''),
-            created_at,
-        ),
+    logger = _db_logger(
+        config,
+        doc_id=doc_id,
+        scope=metadata.get('scope', 'global'),
+        repo=metadata.get('repo', ''),
     )
+    started = observability.now_perf()
+    logger.emit('upsert', 'start', level='debug')
 
-    import struct
-    embedding_blob = struct.pack(f'{len(embedding)}f', *embedding)
-    conn.execute(
-        "INSERT INTO vec_learnings (id, embedding) VALUES (?, ?)",
-        (doc_id, embedding_blob),
-    )
+    try:
+        embedding = get_embedding(content, config=config)
+        created_at = metadata.get('created_at', datetime.now(timezone.utc).isoformat())
 
-    conn.execute(
-        "INSERT INTO fts_learnings (id, content) VALUES (?, ?)",
-        (doc_id, content),
-    )
+        # Delete-then-insert strategy (virtual tables don't support ON CONFLICT cleanly)
+        delete_document(conn, doc_id, config=config)
 
-    conn.commit()
+        conn.execute(
+            """INSERT INTO learnings (id, content, scope, repo, file_path, topic, keywords, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                doc_id,
+                content,
+                metadata.get('scope', 'global'),
+                metadata.get('repo', ''),
+                metadata.get('file_path', ''),
+                metadata.get('topic', 'other'),
+                metadata.get('keywords', ''),
+                created_at,
+            ),
+        )
+
+        import struct
+
+        embedding_blob = struct.pack(f'{len(embedding)}f', *embedding)
+        conn.execute(
+            "INSERT INTO vec_learnings (id, embedding) VALUES (?, ?)",
+            (doc_id, embedding_blob),
+        )
+
+        conn.execute(
+            "INSERT INTO fts_learnings (id, content) VALUES (?, ?)",
+            (doc_id, content),
+        )
+
+        conn.commit()
+        logger.emit(
+            'upsert',
+            'success',
+            duration_ms=observability.elapsed_ms(started),
+            counts={'embedding_dimensions': len(embedding), 'content_bytes': len(content.encode('utf-8'))},
+        )
+    except Exception as exc:
+        logger.emit(
+            'upsert',
+            'error',
+            level='error',
+            duration_ms=observability.elapsed_ms(started),
+            error=exc,
+        )
+        raise
 
 
-def delete_document(conn: sqlite3.Connection, doc_id: str) -> None:
+def delete_document(
+    conn: sqlite3.Connection,
+    doc_id: str,
+    config: Optional[Dict[str, Any]] = None,
+) -> None:
     """Remove a document from all three tables."""
-    conn.execute("DELETE FROM learnings WHERE id = ?", (doc_id,))
-    conn.execute("DELETE FROM vec_learnings WHERE id = ?", (doc_id,))
-    conn.execute("DELETE FROM fts_learnings WHERE id = ?", (doc_id,))
-    conn.commit()
+    logger = _db_logger(config, doc_id=doc_id)
+    started = observability.now_perf()
+    try:
+        primary_deleted = conn.execute("DELETE FROM learnings WHERE id = ?", (doc_id,)).rowcount
+        vec_deleted = conn.execute("DELETE FROM vec_learnings WHERE id = ?", (doc_id,)).rowcount
+        fts_deleted = conn.execute("DELETE FROM fts_learnings WHERE id = ?", (doc_id,)).rowcount
+        conn.commit()
+        logger.emit(
+            'delete',
+            'success',
+            level='debug',
+            duration_ms=observability.elapsed_ms(started),
+            counts={
+                'learnings': max(0, primary_deleted),
+                'vec_learnings': max(0, vec_deleted),
+                'fts_learnings': max(0, fts_deleted),
+            },
+        )
+    except Exception as exc:
+        logger.emit(
+            'delete',
+            'error',
+            level='error',
+            duration_ms=observability.elapsed_ms(started),
+            error=exc,
+        )
+        raise
 
 
 def search(
@@ -229,6 +410,7 @@ def search(
     scope_repos: List[str],
     n_results: int = 10,
     threshold: float = 1.0,
+    config: Optional[Dict[str, Any]] = None,
 ) -> List[Dict[str, Any]]:
     """
     KNN vector search filtered by scope, returns list of result dicts.
@@ -238,62 +420,92 @@ def search(
     """
     import struct
 
-    query_emb = get_embedding(query_text)
-    embedding_blob = struct.pack(f'{len(query_emb)}f', *query_emb)
+    logger = _db_logger(
+        config,
+        query_preview=query_text[:120],
+        scope_repo_count=len(scope_repos),
+        n_results=n_results,
+        threshold=threshold,
+    )
+    started = observability.now_perf()
+    logger.emit('vector_search', 'start', level='debug')
 
-    # Build scope WHERE clause
-    scope_conditions = ["l.scope = 'global'"]
-    params: List[Any] = []
-    for repo in scope_repos:
-        scope_conditions.append("(l.scope = 'repo' AND l.repo = ?)")
-        params.append(repo)
-    scope_sql = ' OR '.join(scope_conditions)
+    try:
+        query_emb = get_embedding(query_text, config=config)
+        embedding_blob = struct.pack(f'{len(query_emb)}f', *query_emb)
 
-    # KNN query joined with learnings for scope filtering
-    # sqlite-vec returns distance as vec_distance_cosine
-    rows = conn.execute(
-        f"""
-        SELECT l.id, l.content, l.scope, l.repo, l.file_path, l.topic, l.keywords,
-               v.distance
-        FROM vec_learnings v
-        JOIN learnings l ON l.id = v.id
-        WHERE v.embedding MATCH ?
-          AND k = ?
-          AND ({scope_sql})
-        ORDER BY v.distance
-        """,
-        [embedding_blob, n_results * 3] + params,
-    ).fetchall()
+        # Build scope WHERE clause
+        scope_conditions = ["l.scope = 'global'"]
+        params: List[Any] = []
+        for repo in scope_repos:
+            scope_conditions.append("(l.scope = 'repo' AND l.repo = ?)")
+            params.append(repo)
+        scope_sql = ' OR '.join(scope_conditions)
 
-    results = []
-    for row in rows:
-        # sqlite-vec cosine distance is in [0, 2]; normalize to [0, 1] so
-        # existing thresholds (0.5, 0.6, 0.25) work unchanged
-        dist = float(row['distance']) / 2.0
-        if dist > threshold:
-            continue
-        results.append({
-            'id': row['id'],
-            'document': row['content'],
-            'metadata': {
-                'scope': row['scope'],
-                'repo': row['repo'],
-                'file_path': row['file_path'],
-                'topic': row['topic'],
-                'keywords': row['keywords'],
-            },
-            'distance': round(dist, 4),
-        })
-        if len(results) >= n_results:
-            break
+        # KNN query joined with learnings for scope filtering
+        # sqlite-vec returns distance as vec_distance_cosine
+        rows = conn.execute(
+            f"""
+            SELECT l.id, l.content, l.scope, l.repo, l.file_path, l.topic, l.keywords,
+                   v.distance
+            FROM vec_learnings v
+            JOIN learnings l ON l.id = v.id
+            WHERE v.embedding MATCH ?
+              AND k = ?
+              AND ({scope_sql})
+            ORDER BY v.distance
+            """,
+            [embedding_blob, n_results * 3] + params,
+        ).fetchall()
 
-    return results
+        results = []
+        for row in rows:
+            # sqlite-vec cosine distance is in [0, 2]; normalize to [0, 1] so
+            # existing thresholds (0.5, 0.6, 0.25) work unchanged
+            dist = float(row['distance']) / 2.0
+            if dist > threshold:
+                continue
+            results.append({
+                'id': row['id'],
+                'document': row['content'],
+                'metadata': {
+                    'scope': row['scope'],
+                    'repo': row['repo'],
+                    'file_path': row['file_path'],
+                    'topic': row['topic'],
+                    'keywords': row['keywords'],
+                },
+                'distance': round(dist, 4),
+            })
+            if len(results) >= n_results:
+                break
+
+        logger.emit(
+            'vector_search',
+            'success',
+            duration_ms=observability.elapsed_ms(started),
+            counts={'raw_rows': len(rows), 'results_returned': len(results)},
+        )
+        return results
+    except Exception as exc:
+        logger.emit(
+            'vector_search',
+            'error',
+            level='error',
+            duration_ms=observability.elapsed_ms(started),
+            error=exc,
+        )
+        raise
 
 
 def get_all_documents(
-    conn: sqlite3.Connection, include_content: bool = True
+    conn: sqlite3.Connection,
+    include_content: bool = True,
+    config: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Return all documents in a dict format compatible with consolidate-discovery."""
+    logger = _db_logger(config, include_content=include_content)
+    started = observability.now_perf()
     rows = conn.execute(
         "SELECT id, content, scope, repo, file_path, topic, keywords FROM learnings"
     ).fetchall()
@@ -313,14 +525,32 @@ def get_all_documents(
             'keywords': row['keywords'],
         })
 
+    logger.emit(
+        'get_all_documents',
+        'success',
+        level='debug',
+        duration_ms=observability.elapsed_ms(started),
+        counts={'documents': len(ids)},
+    )
     return {'ids': ids, 'documents': documents, 'metadatas': metadatas}
 
 
 def get_documents_by_ids(
-    conn: sqlite3.Connection, ids: List[str]
+    conn: sqlite3.Connection,
+    ids: List[str],
+    config: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Fetch specific documents by ID list."""
+    logger = _db_logger(config, requested_ids=len(ids))
+    started = observability.now_perf()
     if not ids:
+        logger.emit(
+            'get_documents_by_ids',
+            'success',
+            level='debug',
+            duration_ms=observability.elapsed_ms(started),
+            counts={'documents': 0},
+        )
         return {'ids': [], 'documents': [], 'metadatas': []}
 
     placeholders = ','.join('?' * len(ids))
@@ -348,10 +578,27 @@ def get_documents_by_ids(
                 'keywords': row['keywords'],
             })
 
+    logger.emit(
+        'get_documents_by_ids',
+        'success',
+        level='debug',
+        duration_ms=observability.elapsed_ms(started),
+        counts={'documents': len(result_ids)},
+    )
     return {'ids': result_ids, 'documents': result_docs, 'metadatas': result_metas}
 
 
-def count_documents(conn: sqlite3.Connection) -> int:
+def count_documents(conn: sqlite3.Connection, config: Optional[Dict[str, Any]] = None) -> int:
     """Return total number of indexed documents."""
+    logger = _db_logger(config)
+    started = observability.now_perf()
     row = conn.execute("SELECT COUNT(*) FROM learnings").fetchone()
-    return row[0] if row else 0
+    total = row[0] if row else 0
+    logger.emit(
+        'count_documents',
+        'success',
+        level='debug',
+        duration_ms=observability.elapsed_ms(started),
+        counts={'documents': total},
+    )
+    return total

--- a/plugins/compound-learning/lib/observability.py
+++ b/plugins/compound-learning/lib/observability.py
@@ -1,0 +1,290 @@
+"""
+Shared observability utilities for compound-learning.
+
+Emits structured JSONL events to a local file with low overhead and no stdout output.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, Iterator, Mapping, MutableMapping, Optional
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - fcntl is unavailable on Windows
+    fcntl = None  # type: ignore[assignment]
+
+
+DEFAULT_LOG_PATH = os.path.expanduser(
+    "~/.claude/plugins/compound-learning/observability.jsonl"
+)
+
+_LEVEL_RANK = {
+    "debug": 10,
+    "info": 20,
+    "warn": 30,
+    "warning": 30,
+    "error": 40,
+}
+
+_APPEND_LOCK = threading.Lock()
+
+
+@dataclass(frozen=True)
+class ObservabilitySettings:
+    enabled: bool
+    level: str
+    log_path: str
+    context: Dict[str, Any]
+
+
+def _coerce_bool(value: Any, default: bool = False) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return default
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+    return default
+
+
+def _normalize_level(level: Any) -> str:
+    normalized = str(level or "info").strip().lower()
+    if normalized == "warning":
+        normalized = "warn"
+    if normalized not in {"debug", "info", "warn", "error"}:
+        return "info"
+    return normalized
+
+
+def _to_jsonable(value: Any) -> Any:
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, Mapping):
+        return {str(k): _to_jsonable(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_to_jsonable(v) for v in value]
+    if isinstance(value, set):
+        return sorted(_to_jsonable(v) for v in value)
+    return str(value)
+
+
+def _clean_fields(fields: Optional[Mapping[str, Any]]) -> Dict[str, Any]:
+    if not fields:
+        return {}
+    cleaned: Dict[str, Any] = {}
+    for key, value in fields.items():
+        if value is None:
+            continue
+        cleaned[str(key)] = _to_jsonable(value)
+    return cleaned
+
+
+def _error_payload(error: Any) -> Dict[str, Any]:
+    if isinstance(error, BaseException):
+        message = str(error).strip() or repr(error)
+        return {
+            "type": error.__class__.__name__,
+            "message": message[:1000],
+        }
+    if isinstance(error, Mapping):
+        return _clean_fields(error)
+    return {"message": str(error)[:1000]}
+
+
+def _now_timestamp() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace(
+        "+00:00", "Z"
+    )
+
+
+def now_perf() -> float:
+    """Return a monotonic timer value for duration calculations."""
+    return time.perf_counter()
+
+
+def elapsed_ms(start_perf: float) -> int:
+    """Return elapsed milliseconds from a perf-counter start value."""
+    return max(0, int(round((time.perf_counter() - start_perf) * 1000)))
+
+
+def resolve_settings(config: Optional[Mapping[str, Any]]) -> ObservabilitySettings:
+    observability_cfg: Mapping[str, Any] = {}
+    if isinstance(config, Mapping):
+        maybe = config.get("observability")
+        if isinstance(maybe, Mapping):
+            observability_cfg = maybe
+
+    enabled = _coerce_bool(observability_cfg.get("enabled"), default=False)
+    level = _normalize_level(observability_cfg.get("level", "info"))
+    log_path = os.path.expanduser(
+        str(observability_cfg.get("logPath") or DEFAULT_LOG_PATH)
+    )
+
+    context = observability_cfg.get("context")
+    if not isinstance(context, Mapping):
+        context = {}
+
+    return ObservabilitySettings(
+        enabled=enabled,
+        level=level,
+        log_path=log_path,
+        context=_clean_fields(context),
+    )
+
+
+def _append_event(path: str, event: Mapping[str, Any]) -> None:
+    line = json.dumps(event, ensure_ascii=True, separators=(",", ":"))
+    log_path = Path(path).expanduser()
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with _APPEND_LOCK:
+        with open(log_path, "a", encoding="utf-8") as handle:
+            if fcntl is not None:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+            handle.write(line)
+            handle.write("\n")
+            handle.flush()
+            if fcntl is not None:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+class StructuredLogger:
+    """Structured JSONL logger with level gating and optional default fields."""
+
+    def __init__(
+        self,
+        component: str,
+        settings: ObservabilitySettings,
+        fields: Optional[Mapping[str, Any]] = None,
+    ) -> None:
+        self.component = component
+        self.settings = settings
+        self._fields = _clean_fields(fields)
+
+    def bind(self, **fields: Any) -> "StructuredLogger":
+        merged: Dict[str, Any] = dict(self._fields)
+        merged.update(_clean_fields(fields))
+        return StructuredLogger(self.component, self.settings, merged)
+
+    def _allows(self, level: str) -> bool:
+        if not self.settings.enabled:
+            return False
+        requested = _LEVEL_RANK.get(_normalize_level(level), 20)
+        minimum = _LEVEL_RANK.get(self.settings.level, 20)
+        return requested >= minimum
+
+    def emit(
+        self,
+        operation: str,
+        status: str,
+        *,
+        level: str = "info",
+        duration_ms: Optional[int] = None,
+        counts: Optional[Mapping[str, Any]] = None,
+        message: Optional[str] = None,
+        error: Any = None,
+        **fields: Any,
+    ) -> None:
+        if not self._allows(level):
+            return
+
+        normalized_level = _normalize_level(level)
+        event: Dict[str, Any] = {
+            "timestamp": _now_timestamp(),
+            "level": normalized_level,
+            "component": self.component,
+            "operation": operation,
+            "status": status,
+        }
+
+        if duration_ms is not None:
+            event["duration_ms"] = max(0, int(duration_ms))
+
+        if message:
+            event["message"] = str(message)
+
+        if counts:
+            cleaned_counts = _clean_fields(counts)
+            if cleaned_counts:
+                event["counts"] = cleaned_counts
+
+        if error is not None:
+            payload = _error_payload(error)
+            if payload:
+                event["error"] = payload
+
+        context = self.settings.context
+        if context:
+            event.update(context)
+
+        if self._fields:
+            event.update(self._fields)
+
+        extra = _clean_fields(fields)
+        if extra:
+            event.update(extra)
+
+        try:
+            _append_event(self.settings.log_path, event)
+        except Exception:
+            # Observability must never change runtime behavior.
+            return
+
+    @contextmanager
+    def timed(
+        self,
+        operation: str,
+        *,
+        level: str = "info",
+        start_level: str = "debug",
+        start_status: str = "start",
+        success_status: str = "success",
+        **fields: Any,
+    ) -> Iterator[None]:
+        start = now_perf()
+        self.emit(operation, start_status, level=start_level, **fields)
+        try:
+            yield
+        except Exception as exc:
+            self.emit(
+                operation,
+                "error",
+                level="error",
+                duration_ms=elapsed_ms(start),
+                error=exc,
+                **fields,
+            )
+            raise
+        else:
+            self.emit(
+                operation,
+                success_status,
+                level=level,
+                duration_ms=elapsed_ms(start),
+                **fields,
+            )
+
+
+def get_logger(
+    component: str,
+    config: Optional[Mapping[str, Any]] = None,
+    **fields: Any,
+) -> StructuredLogger:
+    settings = resolve_settings(config)
+    return StructuredLogger(component, settings, fields)

--- a/plugins/compound-learning/scripts/search-learnings.py
+++ b/plugins/compound-learning/scripts/search-learnings.py
@@ -13,12 +13,14 @@ sys.path.insert(0, _PLUGIN_ROOT)
 
 import json
 import re
+import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import List, Dict, Any, Tuple, Set
 
 import lib.db as db
 import lib.git_utils as git_utils
+import lib.observability as observability
 
 
 # Common stopwords to filter from query keywords
@@ -111,8 +113,14 @@ def calculate_keyword_overlap(keywords: Set[str], document: str) -> float:
     return matches / len(keywords)
 
 
-def fts5_search(conn, query_text: str, limit: int = 50) -> Set[str]:
+def fts5_search(
+    conn,
+    query_text: str,
+    limit: int = 50,
+    logger: observability.StructuredLogger | None = None,
+) -> Set[str]:
     """Return IDs of documents matching FTS5 full-text search."""
+    started = observability.now_perf()
     try:
         tokens = re.findall(r'\b\w+\b', query_text.lower())
         meaningful = [t for t in tokens if t not in STOPWORDS and len(t) >= 2]
@@ -123,8 +131,25 @@ def fts5_search(conn, query_text: str, limit: int = 50) -> Set[str]:
             "SELECT id FROM fts_learnings WHERE content MATCH ? LIMIT ?",
             (fts_query, limit)
         ).fetchall()
-        return {row[0] for row in rows}
+        matches = {row[0] for row in rows}
+        if logger:
+            logger.emit(
+                'fts_query',
+                'success',
+                level='debug',
+                duration_ms=observability.elapsed_ms(started),
+                counts={'matches': len(matches)},
+            )
+        return matches
     except Exception as e:
+        if logger:
+            logger.emit(
+                'fts_query',
+                'error',
+                level='error',
+                duration_ms=observability.elapsed_ms(started),
+                error=e,
+            )
         print(f"FTS5 search error: {e}", file=sys.stderr)
         return set()
 
@@ -166,18 +191,45 @@ def query_single_keyword(
     keyword: str,
     scope_repos: List[str],
     query_size: int,
+    logger: observability.StructuredLogger | None = None,
 ) -> List[Dict[str, Any]]:
     """Query SQLite for a single keyword. Opens its own connection (thread-safe)."""
+    started = observability.now_perf()
     try:
         conn = db.get_connection(config)
         try:
-            results = db.search(conn, keyword, scope_repos, n_results=query_size, threshold=1.0)
+            results = db.search(
+                conn,
+                keyword,
+                scope_repos,
+                n_results=query_size,
+                threshold=1.0,
+                config=config,
+            )
             for r in results:
                 r['matched_keyword'] = keyword
+            if logger:
+                logger.emit(
+                    'keyword_query',
+                    'success',
+                    level='debug',
+                    duration_ms=observability.elapsed_ms(started),
+                    counts={'result_count': len(results)},
+                    keyword=keyword,
+                )
             return results
         finally:
             conn.close()
     except Exception as e:
+        if logger:
+            logger.emit(
+                'keyword_query',
+                'error',
+                level='error',
+                duration_ms=observability.elapsed_ms(started),
+                error=e,
+                keyword=keyword,
+            )
         print(f"Error in query_single_keyword: {e}", file=sys.stderr)
         return []
 
@@ -211,6 +263,35 @@ def search_learnings(
     Returns high confidence results (distance < 0.5) and possibly relevant (0.5-0.7).
     """
     config = db.load_config()
+    obs_cfg = config.setdefault('observability', {})
+    if not isinstance(obs_cfg, dict):
+        obs_cfg = {}
+        config['observability'] = obs_cfg
+    obs_context = obs_cfg.get('context')
+    if not isinstance(obs_context, dict):
+        obs_context = {}
+    obs_context.setdefault(
+        'correlation_id',
+        os.environ.get('LEARNINGS_OBS_CORRELATION_ID') or uuid.uuid4().hex,
+    )
+    session_id = os.environ.get('CLAUDE_SESSION_ID') or os.environ.get('CLAUDE_SESSION')
+    if session_id:
+        obs_context.setdefault('session_id', session_id)
+    obs_cfg['context'] = obs_context
+    logger = observability.get_logger(
+        'search',
+        config,
+        operation_name='search_learnings',
+    )
+    started = observability.now_perf()
+    logger.emit(
+        'search_request',
+        'start',
+        level='info',
+        counts={'max_results': max_results},
+        query_preview=query[:120],
+    )
+
     high_threshold = threshold_override if threshold_override is not None else config['learnings']['highConfidenceThreshold']
     possible_threshold = config['learnings']['possiblyRelevantThreshold']
     keyword_weight = config['learnings']['keywordBoostWeight']
@@ -227,6 +308,13 @@ def search_learnings(
         keywords = [query] if query else []
 
     if not keywords:
+        logger.emit(
+            'search_request',
+            'empty',
+            level='info',
+            duration_ms=observability.elapsed_ms(started),
+            message='No keywords provided',
+        )
         print(json.dumps({'status': 'empty', 'message': 'No keywords provided'}))
         return
 
@@ -239,12 +327,28 @@ def search_learnings(
     query_keywords: Set[str] = set()
     for kw in keywords:
         query_keywords.update(extract_query_keywords(kw))
+    logger.emit(
+        'keyword_parse',
+        'success',
+        level='debug',
+        counts={
+            'keywords_requested': len(keywords),
+            'query_keywords': len(query_keywords),
+        },
+    )
 
     cwd = working_dir if working_dir else os.getcwd()
     home = os.path.expanduser('~')
 
     # Detect repo hierarchy
     repos = detect_learning_hierarchy(cwd, home)
+    logger.emit(
+        'scope_detection',
+        'success',
+        level='info',
+        counts={'repos_in_scope': len(repos)},
+        working_dir=cwd,
+    )
 
     try:
         # Parse exclusion IDs upfront to determine query size
@@ -256,9 +360,10 @@ def search_learnings(
 
         # Run parallel queries for each keyword; each call opens its own connection
         all_results: List[List[Dict[str, Any]]] = []
+        fanout_started = observability.now_perf()
         with ThreadPoolExecutor(max_workers=min(len(keywords), 8)) as executor:
             futures = {
-                executor.submit(query_single_keyword, config, kw, repos, query_size): kw
+                executor.submit(query_single_keyword, config, kw, repos, query_size, logger): kw
                 for kw in keywords
             }
             for future in as_completed(futures):
@@ -267,19 +372,47 @@ def search_learnings(
                     all_results.append(result)
                 except Exception as e:
                     print(f"Error in search_learnings: {e}", file=sys.stderr)
+                    logger.emit(
+                        'parallel_fanout',
+                        'error',
+                        level='error',
+                        error=e,
+                    )
+        logger.emit(
+            'parallel_fanout',
+            'success',
+            duration_ms=observability.elapsed_ms(fanout_started),
+            counts={'keywords_searched': len(keywords), 'result_sets': len(all_results)},
+        )
 
         # Merge results from parallel queries
         raw_results = merge_parallel_results(all_results)
+        logger.emit(
+            'merge_results',
+            'success',
+            level='debug',
+            counts={'raw_candidates': len(raw_results)},
+        )
 
         # Get FTS5 matches for additional signal
+        fts_started = observability.now_perf()
         conn_fts = db.get_connection(config)
         try:
-            fts_matches = fts5_search(conn_fts, ' '.join(keywords))
+            fts_matches = fts5_search(conn_fts, ' '.join(keywords), logger=logger)
         finally:
             conn_fts.close()
+        logger.emit(
+            'fts_lookup',
+            'success',
+            level='debug',
+            duration_ms=observability.elapsed_ms(fts_started),
+            counts={'fts_matches': len(fts_matches)},
+        )
 
         # Apply hybrid re-ranking (keyword boost + FTS5 signal)
+        rerank_started = observability.now_perf()
         reranked_results = hybrid_rerank(raw_results, query_keywords, keyword_weight, fts_ids=fts_matches)
+        reranked_initial = len(reranked_results)
 
         # Discard results with zero keyword overlap (unless they have very high
         # semantic similarity, i.e., distance < 0.25 before keyword adjustment)
@@ -287,10 +420,23 @@ def search_learnings(
             r for r in reranked_results
             if r.get('keyword_overlap', 0) > 0 or r.get('original_distance', 1.0) < 0.25
         ]
+        after_overlap_filter = len(reranked_results)
 
         # Filter out excluded IDs
         if exclude_set:
             reranked_results = [r for r in reranked_results if r['id'] not in exclude_set]
+        after_exclusion = len(reranked_results)
+        logger.emit(
+            'rerank_filter',
+            'success',
+            duration_ms=observability.elapsed_ms(rerank_started),
+            counts={
+                'reranked_candidates': reranked_initial,
+                'after_overlap_filter': after_overlap_filter,
+                'after_exclusion': after_exclusion,
+                'excluded_ids': len(exclude_set),
+            },
+        )
 
         # Split results into tiers based on adjusted distance
         high_confidence: List[Dict[str, Any]] = []
@@ -301,6 +447,16 @@ def search_learnings(
                 high_confidence.append(result)
             elif result['distance'] < possible_threshold:
                 possibly_relevant.append(result)
+        logger.emit(
+            'threshold_bucketing',
+            'success',
+            counts={
+                'high_confidence': len(high_confidence),
+                'possibly_relevant': len(possibly_relevant),
+                'possible_threshold': possible_threshold,
+                'high_threshold': high_threshold,
+            },
+        )
 
         # Peek mode: high_confidence first, backfill from possibly_relevant up to max_results
         if peek_mode:
@@ -319,6 +475,14 @@ def search_learnings(
             else:
                 output = {'status': 'empty', 'keywords_searched': keywords}
 
+            logger.emit(
+                'search_complete',
+                output['status'],
+                level='info',
+                duration_ms=observability.elapsed_ms(started),
+                counts={'results_returned': output.get('count', 0)},
+                peek_mode=True,
+            )
             print(json.dumps(output, indent=2))
             return
 
@@ -350,9 +514,28 @@ def search_learnings(
                 'possibly_relevant': possibly_relevant
             }
 
+        logger.emit(
+            'search_complete',
+            output['status'],
+            level='info',
+            duration_ms=observability.elapsed_ms(started),
+            counts={
+                'high_confidence': len(high_confidence),
+                'possibly_relevant': len(possibly_relevant),
+                'raw_candidates': len(raw_results),
+            },
+            peek_mode=False,
+        )
         print(json.dumps(output, indent=2))
 
     except Exception as e:
+        logger.emit(
+            'search_complete',
+            'error',
+            level='error',
+            duration_ms=observability.elapsed_ms(started),
+            error=e,
+        )
         error_output = {
             'status': 'error',
             'message': str(e),

--- a/plugins/compound-learning/skills/index-learnings/index-learnings.py
+++ b/plugins/compound-learning/skills/index-learnings/index-learnings.py
@@ -13,6 +13,7 @@ sys.path.insert(0, _PLUGIN_ROOT)
 
 import hashlib
 import re
+import uuid
 from pathlib import Path
 from datetime import datetime, timezone
 from collections import defaultdict
@@ -20,6 +21,7 @@ from typing import Dict, List, Tuple, Any
 
 import lib.db as db
 import lib.git_utils as git_utils
+import lib.observability as observability
 from lib.topic_mapping import infer_topic_from_tags
 
 
@@ -127,6 +129,8 @@ def extract_type(content: str) -> str | None:
 
 def generate_manifest(manifest_data: Dict[str, List[Dict[str, Any]]], config: Dict[str, Any]) -> None:
     """Generate single manifest file at ~/.projects/learnings/MANIFEST.md"""
+    logger = observability.get_logger('index', config)
+    started = observability.now_perf()
     global_dir = Path(config['learnings']['globalDir'])
     global_dir.mkdir(parents=True, exist_ok=True)
     manifest_path = global_dir / 'MANIFEST.md'
@@ -148,9 +152,27 @@ def generate_manifest(manifest_data: Dict[str, List[Dict[str, Any]]], config: Di
             continue
         lines.extend(_format_section(f"Repo: {scope}", manifest_data[scope]))
 
-    with open(manifest_path, 'w', encoding='utf-8') as f:
-        f.write('\n'.join(lines))
+    try:
+        with open(manifest_path, 'w', encoding='utf-8') as f:
+            f.write('\n'.join(lines))
+    except Exception as exc:
+        logger.emit(
+            'manifest_generation',
+            'error',
+            level='error',
+            duration_ms=observability.elapsed_ms(started),
+            error=exc,
+            manifest_path=str(manifest_path),
+        )
+        raise
 
+    logger.emit(
+        'manifest_generation',
+        'success',
+        duration_ms=observability.elapsed_ms(started),
+        counts={'scopes': len(manifest_data), 'entries': sum(len(v) for v in manifest_data.values())},
+        manifest_path=str(manifest_path),
+    )
     print(f"\n[OK] Generated manifest: {manifest_path}")
 
 
@@ -194,9 +216,18 @@ def _format_section(title: str, learnings: List[Dict[str, Any]]) -> List[str]:
 
 def index_single_file(file_path: Path, config: Dict[str, Any]) -> bool:
     """Index a single learning file into SQLite. Returns True on success."""
+    logger = observability.get_logger('index', config, file_path=str(file_path))
+    started = observability.now_perf()
     try:
         conn = db.get_connection(config)
     except Exception as e:
+        logger.emit(
+            'single_file_connection',
+            'error',
+            level='error',
+            duration_ms=observability.elapsed_ms(started),
+            error=e,
+        )
         print(f"[WARN] Failed to open database, skipping index: {e}")
         return False
 
@@ -211,9 +242,24 @@ def index_single_file(file_path: Path, config: Dict[str, Any]) -> bool:
         metadata['keywords'] = ','.join(keywords)
 
         doc_id = hashlib.md5(str(file_path.resolve()).encode()).hexdigest()
-        db.upsert_document(conn, doc_id, content, metadata)
+        db.upsert_document(conn, doc_id, content, metadata, config=config)
+        logger.emit(
+            'single_file_index',
+            'success',
+            duration_ms=observability.elapsed_ms(started),
+            counts={'keywords': len(keywords)},
+            doc_id=doc_id,
+            topic=topic,
+        )
         return True
     except Exception as e:
+        logger.emit(
+            'single_file_index',
+            'error',
+            level='error',
+            duration_ms=observability.elapsed_ms(started),
+            error=e,
+        )
         print(f"[ERROR] Failed to index {file_path.name}: {e}")
         return False
     finally:
@@ -222,25 +268,70 @@ def index_single_file(file_path: Path, config: Dict[str, Any]) -> bool:
 
 def index_learning_files():
     """Main indexing function."""
+    started = observability.now_perf()
     print("Loading configuration...")
     config = db.load_config()
+    obs_cfg = config.setdefault('observability', {})
+    if not isinstance(obs_cfg, dict):
+        obs_cfg = {}
+        config['observability'] = obs_cfg
+    context = obs_cfg.get('context')
+    if not isinstance(context, dict):
+        context = {}
+    context.setdefault(
+        'correlation_id',
+        os.environ.get('LEARNINGS_OBS_CORRELATION_ID') or uuid.uuid4().hex,
+    )
+    session_id = os.environ.get('CLAUDE_SESSION_ID') or os.environ.get('CLAUDE_SESSION')
+    if session_id:
+        context.setdefault('session_id', session_id)
+    obs_cfg['context'] = context
+
+    logger = observability.get_logger('index', config, operation_name='index_learning_files')
+    logger.emit('index_pipeline', 'start', level='info')
 
     print("Opening database...")
     try:
         conn = db.get_connection(config)
         print(f"[OK] Database ready")
     except Exception as e:
+        logger.emit(
+            'index_pipeline',
+            'error',
+            level='error',
+            duration_ms=observability.elapsed_ms(started),
+            error=e,
+            message='Failed to open database',
+        )
         print(f"[ERROR] Failed to open database: {e}")
         sys.exit(1)
 
     print("\nDiscovering learning files...")
+    discovery_started = observability.now_perf()
     global_files, repo_files_by_name = find_all_learning_files(config)
     repo_files = [f for files in repo_files_by_name.values() for f in files]
     all_files = global_files + repo_files
 
+    logger.emit(
+        'file_discovery',
+        'success',
+        duration_ms=observability.elapsed_ms(discovery_started),
+        counts={
+            'global_files': len(global_files),
+            'repo_files': len(repo_files),
+            'repos': len(repo_files_by_name),
+            'total_files': len(all_files),
+        },
+    )
     print(f"Found {len(all_files)} files (Global: {len(global_files)}, Repos: {len(repo_files)})")
 
     if not all_files:
+        logger.emit(
+            'index_pipeline',
+            'empty',
+            level='info',
+            duration_ms=observability.elapsed_ms(started),
+        )
         print("\nNo learning files found. Run /compound to create some!")
         conn.close()
         return
@@ -248,6 +339,7 @@ def index_learning_files():
     print("\nIndexing...")
     manifest_data: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
     indexed = 0
+    failed_files = 0
 
     for file_path in all_files:
         try:
@@ -262,7 +354,7 @@ def index_learning_files():
             metadata['keywords'] = ','.join(keywords)
 
             doc_id = hashlib.md5(str(file_path.resolve()).encode()).hexdigest()
-            db.upsert_document(conn, doc_id, content, metadata)
+            db.upsert_document(conn, doc_id, content, metadata, config=config)
 
             scope_key = metadata['repo'] if metadata['scope'] == 'repo' else 'global'
             manifest_data[scope_key].append({
@@ -276,26 +368,54 @@ def index_learning_files():
                 print(f"  {indexed}/{len(all_files)}...")
 
         except Exception as e:
+            failed_files += 1
+            logger.emit(
+                'file_index',
+                'error',
+                level='error',
+                error=e,
+                file_path=str(file_path),
+            )
             print(f"  [ERROR] {file_path.name}: {e}")
 
+    logger.emit(
+        'file_index',
+        'success',
+        counts={'indexed': indexed, 'failed': failed_files, 'total': len(all_files)},
+    )
+
     # Prune orphaned entries whose files no longer exist on disk
-    all_docs = db.get_all_documents(conn, include_content=False)
+    prune_started = observability.now_perf()
+    all_docs = db.get_all_documents(conn, include_content=False, config=config)
     pruned = 0
     for doc_id, metadata in zip(all_docs['ids'], all_docs['metadatas']):
         file_path_str = metadata.get('file_path', '')
         if file_path_str and not os.path.exists(file_path_str):
-            db.delete_document(conn, doc_id)
+            db.delete_document(conn, doc_id, config=config)
             pruned += 1
     if pruned:
         print(f"[OK] Pruned {pruned} orphaned entries")
     else:
         print("[OK] No orphaned entries found")
+    logger.emit(
+        'prune_orphans',
+        'success',
+        duration_ms=observability.elapsed_ms(prune_started),
+        counts={'candidates': len(all_docs['ids']), 'pruned': pruned},
+    )
 
     conn.close()
     print(f"\n[OK] Indexed {indexed} files")
 
     if manifest_data:
         generate_manifest(manifest_data, config)
+
+    logger.emit(
+        'index_pipeline',
+        'success',
+        duration_ms=observability.elapsed_ms(started),
+        counts={'indexed': indexed, 'failed': failed_files, 'pruned': pruned},
+    )
 
 
 if __name__ == '__main__':

--- a/plugins/compound-learning/tests/test_observability.py
+++ b/plugins/compound-learning/tests/test_observability.py
@@ -1,0 +1,131 @@
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+PLUGIN_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(PLUGIN_ROOT))
+
+import lib.observability as observability
+
+_search_spec = importlib.util.spec_from_file_location(
+    "search_learnings",
+    PLUGIN_ROOT / "scripts" / "search-learnings.py",
+)
+search_module = importlib.util.module_from_spec(_search_spec)
+_search_spec.loader.exec_module(search_module)
+
+
+def test_structured_event_shape(tmp_path):
+    log_path = tmp_path / "observability.jsonl"
+    config = {
+        "observability": {
+            "enabled": True,
+            "level": "debug",
+            "logPath": str(log_path),
+            "context": {
+                "correlation_id": "corr-123",
+                "session_id": "sess-123",
+            },
+        }
+    }
+    logger = observability.get_logger("search", config, operation_name="unit-test")
+    logger.emit(
+        "fanout",
+        "success",
+        level="info",
+        duration_ms=12,
+        counts={"keywords": 2},
+        message="fanout completed",
+    )
+
+    lines = log_path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 1
+
+    event = json.loads(lines[0])
+    assert event["timestamp"]
+    assert event["level"] == "info"
+    assert event["component"] == "search"
+    assert event["operation"] == "fanout"
+    assert event["status"] == "success"
+    assert event["duration_ms"] == 12
+    assert event["counts"]["keywords"] == 2
+    assert event["correlation_id"] == "corr-123"
+    assert event["session_id"] == "sess-123"
+    assert event["operation_name"] == "unit-test"
+
+
+def test_level_filtering(tmp_path):
+    log_path = tmp_path / "observability.jsonl"
+    config = {
+        "observability": {
+            "enabled": True,
+            "level": "warn",
+            "logPath": str(log_path),
+        }
+    }
+    logger = observability.get_logger("db", config)
+    logger.emit("vector_search", "success", level="info")
+    logger.emit("vector_search", "error", level="error")
+
+    lines = log_path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 1
+    assert json.loads(lines[0])["level"] == "error"
+
+
+def test_search_stdout_contract_with_observability(monkeypatch, capsys, tmp_path):
+    log_path = tmp_path / "search-observability.jsonl"
+    config = {
+        "learnings": {
+            "highConfidenceThreshold": 0.40,
+            "possiblyRelevantThreshold": 0.55,
+            "keywordBoostWeight": 0.65,
+        },
+        "observability": {
+            "enabled": True,
+            "level": "debug",
+            "logPath": str(log_path),
+        },
+    }
+
+    class FakeConn:
+        def close(self):
+            return None
+
+    def fake_query_single_keyword(_config, keyword, _scope_repos, _query_size, logger=None):
+        if logger:
+            logger.emit(
+                "keyword_query",
+                "success",
+                level="debug",
+                counts={"result_count": 1},
+                keyword=keyword,
+            )
+        return [
+            {
+                "id": "learning-1",
+                "document": "JWT authentication pattern",
+                "metadata": {"scope": "global", "repo": "", "file_path": "/tmp/a.md", "topic": "auth", "keywords": "jwt"},
+                "distance": 0.20,
+            }
+        ]
+
+    monkeypatch.setattr(search_module.db, "load_config", lambda: config)
+    monkeypatch.setattr(search_module, "detect_learning_hierarchy", lambda _cwd, _home: [])
+    monkeypatch.setattr(search_module, "query_single_keyword", fake_query_single_keyword)
+    monkeypatch.setattr(search_module.db, "get_connection", lambda _config: FakeConn())
+    monkeypatch.setattr(search_module, "fts5_search", lambda _conn, _query, limit=50, logger=None: set())
+
+    search_module.search_learnings(
+        "jwt auth",
+        working_dir=str(tmp_path),
+        max_results=2,
+        keywords_json='["jwt auth"]',
+    )
+    output = capsys.readouterr().out
+
+    payload = json.loads(output)
+    assert payload["status"] == "success"
+    assert "high_confidence" in payload
+    assert log_path.exists()
+    assert log_path.read_text(encoding="utf-8").strip()


### PR DESCRIPTION
## Scope
- add shared Python observability utility with JSONL structured events, timing helpers, and safe append behavior
- instrument DB operations (connection/schema/embedding/upsert/delete/search) with status, latency, counts, and errors
- instrument search pipeline orchestration and index pipeline lifecycle without changing stdout JSON/text contracts
- refactor hook logging via shared shell helper and emit hook lifecycle/subprocess/skip events for setup, auto-peek, and extract-learnings
- document observability config/env toggles and add focused observability tests

## Validation
- `python3 -m py_compile ...`
- `bash -n plugins/compound-learning/hooks/*.sh`
- `pytest plugins/compound-learning/tests -q`
- hook smoke checks for setup/auto-peek/extract-learnings skip paths
