### PR TITLE
Auto DRY: share learning metadata parsing helpers

### DIFF
--- a/plugins/compound-learning/lib/learning_metadata.py
+++ b/plugins/compound-learning/lib/learning_metadata.py
@@ -1,0 +1,30 @@
+"""Shared parsing helpers for learning markdown metadata fields."""
+
+from __future__ import annotations
+
+import re
+
+
+def extract_field(content: str, field: str) -> str | None:
+    """Extract a markdown metadata field value from `**Field:** value`."""
+    pattern = rf"\*\*{re.escape(field)}:\*\*\s*(.+?)(?:\n|$)"
+    match = re.search(pattern, content, re.IGNORECASE)
+    return match.group(1).strip() if match else None
+
+
+def extract_tags(
+    content: str,
+    *,
+    strip_brackets: bool = False,
+    max_tags: int = 8,
+) -> list[str]:
+    """Extract normalised tags from `**Tags:**` metadata."""
+    tags_str = extract_field(content, "Tags")
+    if not tags_str:
+        return []
+
+    if strip_brackets:
+        tags_str = tags_str.strip("[]")
+
+    tags = [tag.strip().lower() for tag in tags_str.split(",") if tag.strip()]
+    return tags[:max_tags]

--- a/plugins/compound-learning/scripts/backfill-topics.py
+++ b/plugins/compound-learning/scripts/backfill-topics.py
@@ -22,26 +22,8 @@ _PLUGIN_ROOT = os.environ.get(
 )
 sys.path.insert(0, _PLUGIN_ROOT)
 
+from lib.learning_metadata import extract_field, extract_tags
 from lib.topic_mapping import infer_topic_from_tags
-
-
-def extract_field(content: str, field: str) -> str | None:
-    """Extract a **Field:** value from learning content.
-
-    Mirrors the pattern used in index-learnings.py for consistency.
-    """
-    match = re.search(rf"\*\*{field}:\*\*\s*(.+?)(?:\n|$)", content, re.IGNORECASE)
-    return match.group(1).strip() if match else None
-
-
-def extract_tags(content: str) -> list[str]:
-    """Extract and normalise tags from **Tags:** field."""
-    tags_str = extract_field(content, "Tags")
-    if not tags_str:
-        return []
-    # Strip surrounding brackets that appear in some files, e.g. [tag1, tag2]
-    tags_str = tags_str.strip("[]")
-    return [t.strip().lower() for t in tags_str.split(",") if t.strip()][:8]
 
 
 def insert_topic_line(content: str, topic: str) -> str:
@@ -80,7 +62,7 @@ def process_file(
     if extract_field(content, "Topic"):
         return False, None
 
-    tags = extract_tags(content)
+    tags = extract_tags(content, strip_brackets=True, max_tags=8)
     topic = infer_topic_from_tags(tags)
     new_content = insert_topic_line(content, topic)
 

--- a/plugins/compound-learning/skills/index-learnings/index-learnings.py
+++ b/plugins/compound-learning/skills/index-learnings/index-learnings.py
@@ -12,7 +12,6 @@ _PLUGIN_ROOT = os.environ.get('CLAUDE_PLUGIN_ROOT', os.path.dirname(os.path.dirn
 sys.path.insert(0, _PLUGIN_ROOT)
 
 import hashlib
-import re
 from pathlib import Path
 from datetime import datetime, timezone
 from collections import defaultdict
@@ -21,6 +20,7 @@ from typing import Dict, List, Tuple, Any
 import lib.db as db
 import lib.git_utils as git_utils
 import lib.observability as observability
+from lib.learning_metadata import extract_field, extract_tags
 from lib.topic_mapping import infer_topic_from_tags
 
 
@@ -99,26 +99,12 @@ def extract_metadata_from_path(file_path: Path, config: Dict[str, Any]) -> Dict[
     return {"scope": "repo", "repo": repo_name, "file_path": path_str}
 
 
-def extract_field(content: str, field: str) -> str | None:
-    """Extract a **Field:** value from learning content."""
-    match = re.search(rf'\*\*{field}:\*\*\s*(.+?)(?:\n|$)', content, re.IGNORECASE)
-    return match.group(1).strip() if match else None
-
-
 def extract_topic(content: str) -> str:
     """Extract topic from **Topic:** field, fallback to tag-based inference."""
     topic = extract_field(content, 'Topic')
     if topic:
         return topic.lower().replace(' ', '-')
     return infer_topic_from_tags(extract_tags(content))
-
-
-def extract_tags(content: str) -> List[str]:
-    """Extract tags from **Tags:** field."""
-    tags_str = extract_field(content, 'Tags')
-    if tags_str:
-        return [t.strip().lower() for t in tags_str.split(',') if t.strip()][:8]
-    return []
 
 
 def extract_type(content: str) -> str | None:

--- a/plugins/compound-learning/tests/test_learning_metadata.py
+++ b/plugins/compound-learning/tests/test_learning_metadata.py
@@ -1,0 +1,41 @@
+import sys
+from pathlib import Path
+
+PLUGIN_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(PLUGIN_ROOT))
+
+from lib.learning_metadata import extract_field, extract_tags
+
+
+def test_extract_field_is_case_insensitive():
+    content = "**tOpIc:** API Design\n"
+    assert extract_field(content, "Topic") == "API Design"
+
+
+def test_extract_field_missing_returns_none():
+    content = "# No metadata here\n"
+    assert extract_field(content, "Topic") is None
+
+
+def test_extract_tags_plain_tags_are_normalized():
+    content = "**tAgS:** Auth, jwt , security \n"
+    assert extract_tags(content) == ["auth", "jwt", "security"]
+
+
+def test_extract_tags_bracketed_tags_can_be_preserved_or_stripped():
+    content = "**Tags:** [Auth, jwt, security]\n"
+    assert extract_tags(content) == ["[auth", "jwt", "security]"]
+    assert extract_tags(content, strip_brackets=True) == ["auth", "jwt", "security"]
+
+
+def test_extract_tags_respects_max_tag_limit():
+    tags = ", ".join(f"tag{i}" for i in range(1, 11))
+    content = f"**Tags:** {tags}\n"
+
+    assert extract_tags(content) == [f"tag{i}" for i in range(1, 9)]
+    assert extract_tags(content, max_tags=3) == ["tag1", "tag2", "tag3"]
+
+
+def test_extract_tags_missing_returns_empty_list():
+    content = "**Topic:** observability\n"
+    assert extract_tags(content) == []


### PR DESCRIPTION
## Summary
- extract duplicated markdown metadata parsing into a shared `lib/learning_metadata.py` helper
- refactor `index-learnings.py` and `backfill-topics.py` to import shared `extract_field`/`extract_tags`
- preserve caller behavior with helper options (`strip_brackets`, `max_tags`)
- add focused regression tests for metadata parsing compatibility

## Verification
- pytest plugins/compound-learning/tests/test_learning_metadata.py
- python3 plugins/compound-learning/skills/index-learnings/index-learnings.py --help
- python3 plugins/compound-learning/scripts/backfill-topics.py --help
- pytest plugins/compound-learning/tests/test_observability.py