### PR TITLE
fix: restore threshold config backward compatibility

### DIFF
--- a/plugins/compound-learning/.claude-plugin/config.json
+++ b/plugins/compound-learning/.claude-plugin/config.json
@@ -5,7 +5,9 @@
   "learnings": {
     "globalDir": "${HOME}/.projects/learnings",
     "repoSearchPath": "${HOME}",
-    "distanceThreshold": 0.5
+    "highConfidenceThreshold": 0.4,
+    "possiblyRelevantThreshold": 0.55,
+    "keywordBoostWeight": 0.65
   },
   "observability": {
     "enabled": false,

--- a/plugins/compound-learning/README.md
+++ b/plugins/compound-learning/README.md
@@ -38,7 +38,10 @@ Run `/index-learnings` to build the index. The SQLite database is created automa
 |----------|-------------|---------|
 | `LEARNINGS_GLOBAL_DIR` | Global learnings directory | `~/.projects/learnings` |
 | `LEARNINGS_REPO_SEARCH_PATH` | Base path to search for repo learnings | `~` |
-| `LEARNINGS_DISTANCE_THRESHOLD` | Similarity threshold (0-1, lower = more similar) | `0.5` |
+| `LEARNINGS_HIGH_CONFIDENCE_THRESHOLD` | High-confidence similarity threshold (0-1, lower = more similar) | `0.4` |
+| `LEARNINGS_POSSIBLY_RELEVANT_THRESHOLD` | Possibly-relevant similarity threshold (0-1) | `0.55` |
+| `LEARNINGS_KEYWORD_BOOST_WEIGHT` | Hybrid rerank keyword boost weight (0-1) | `0.65` |
+| `LEARNINGS_DISTANCE_THRESHOLD` | Legacy single-threshold fallback, used only when new tiered keys are not set | Legacy compatibility |
 | `LEARNINGS_OBS_ENABLED` | Enable structured observability events (`true`/`false`) | `false` |
 | `LEARNINGS_OBS_LEVEL` | Minimum observability level (`debug`, `info`, `warn`, `error`) | `info` |
 | `LEARNINGS_OBS_LOG_PATH` | JSONL observability log path | `~/.claude/plugins/compound-learning/observability.jsonl` |
@@ -67,7 +70,9 @@ Create `.claude-plugin/config.json` in the plugin directory:
   "learnings": {
     "globalDir": "${HOME}/.projects/learnings",
     "repoSearchPath": "${HOME}",
-    "distanceThreshold": 0.5
+    "highConfidenceThreshold": 0.4,
+    "possiblyRelevantThreshold": 0.55,
+    "keywordBoostWeight": 0.65
   },
   "observability": {
     "enabled": false,
@@ -78,6 +83,12 @@ Create `.claude-plugin/config.json` in the plugin directory:
 ```
 
 `${HOME}` expands to your home directory.
+
+Threshold precedence and backward compatibility:
+- New tiered env vars (`LEARNINGS_HIGH_CONFIDENCE_THRESHOLD`, `LEARNINGS_POSSIBLY_RELEVANT_THRESHOLD`, `LEARNINGS_KEYWORD_BOOST_WEIGHT`) override config file values.
+- New tiered config keys (`highConfidenceThreshold`, `possiblyRelevantThreshold`, `keywordBoostWeight`) override legacy `distanceThreshold`.
+- Legacy `LEARNINGS_DISTANCE_THRESHOLD` overrides legacy `distanceThreshold` when tiered keys are not explicitly set.
+- If thresholds are misordered (`possiblyRelevantThreshold < highConfidenceThreshold`), runtime aligns `possiblyRelevantThreshold` to `highConfidenceThreshold` and logs a warning.
 
 ### Observability Events
 
@@ -233,7 +244,8 @@ Use topic + context: "authentication JWT refresh" not "implement login feature"
 - Check config paths in `.claude-plugin/config.json`
 
 **Search returns no results:**
-- Check `distanceThreshold` setting (try increasing to 0.7)
+- Check threshold settings (`highConfidenceThreshold` / `possiblyRelevantThreshold`) and try increasing `possiblyRelevantThreshold` (for example to `0.7`)
+- If using legacy config, check `distanceThreshold` or `LEARNINGS_DISTANCE_THRESHOLD`
 - Run `/index-learnings` to ensure learnings are indexed
 
 **Hook activity log:**

--- a/plugins/compound-learning/lib/db.py
+++ b/plugins/compound-learning/lib/db.py
@@ -58,6 +58,32 @@ def _normalize_level(value: Any) -> str:
     return level
 
 
+def _coerce_float(value: Any) -> float | None:
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return None
+        try:
+            return float(stripped)
+        except ValueError:
+            return None
+    return None
+
+
+def _parse_env_float(var_name: str, raw_value: Any) -> float | None:
+    if raw_value is None:
+        return None
+    value = _coerce_float(raw_value)
+    if value is None:
+        print(
+            f"Warning: Invalid numeric value for {var_name}: {raw_value!r}; ignoring.",
+            file=sys.stderr,
+        )
+    return value
+
+
 def _db_logger(
     config: Optional[Mapping[str, Any]],
     **fields: Any,
@@ -120,8 +146,39 @@ def load_config() -> Dict[str, Any]:
     env_obs_enabled = os.environ.get('LEARNINGS_OBS_ENABLED')
     env_obs_level = os.environ.get('LEARNINGS_OBS_LEVEL')
     env_obs_log_path = os.environ.get('LEARNINGS_OBS_LOG_PATH')
+    env_distance_threshold = _parse_env_float(
+        'LEARNINGS_DISTANCE_THRESHOLD',
+        os.environ.get('LEARNINGS_DISTANCE_THRESHOLD'),
+    )
+    env_high_confidence_threshold = _parse_env_float(
+        'LEARNINGS_HIGH_CONFIDENCE_THRESHOLD',
+        os.environ.get('LEARNINGS_HIGH_CONFIDENCE_THRESHOLD'),
+    )
+    env_possibly_relevant_threshold = _parse_env_float(
+        'LEARNINGS_POSSIBLY_RELEVANT_THRESHOLD',
+        os.environ.get('LEARNINGS_POSSIBLY_RELEVANT_THRESHOLD'),
+    )
+    env_keyword_boost_weight = _parse_env_float(
+        'LEARNINGS_KEYWORD_BOOST_WEIGHT',
+        os.environ.get('LEARNINGS_KEYWORD_BOOST_WEIGHT'),
+    )
 
     result = _deep_merge(defaults, file_config)
+    file_learnings = file_config.get('learnings')
+    if not isinstance(file_learnings, dict):
+        file_learnings = {}
+
+    file_has_high_confidence = 'highConfidenceThreshold' in file_learnings
+    file_has_possibly_relevant = 'possiblyRelevantThreshold' in file_learnings
+
+    file_distance_threshold: float | None = None
+    if 'distanceThreshold' in file_learnings:
+        file_distance_threshold = _coerce_float(file_learnings.get('distanceThreshold'))
+        if file_distance_threshold is None:
+            print(
+                "Warning: Invalid numeric value for learnings.distanceThreshold in config file; ignoring.",
+                file=sys.stderr,
+            )
 
     if env_db_path:
         result['sqlite']['dbPath'] = os.path.expanduser(env_db_path)
@@ -137,6 +194,72 @@ def load_config() -> Dict[str, Any]:
         result['observability']['level'] = _normalize_level(env_obs_level)
     if env_obs_log_path:
         result['observability']['logPath'] = os.path.expanduser(env_obs_log_path)
+
+    legacy_distance_threshold = (
+        env_distance_threshold
+        if env_distance_threshold is not None
+        else file_distance_threshold
+    )
+
+    learnings = result.setdefault('learnings', {})
+    if not isinstance(learnings, dict):
+        learnings = {}
+        result['learnings'] = learnings
+
+    # Legacy compatibility: distanceThreshold only applies when tiered keys are absent.
+    if env_high_confidence_threshold is not None:
+        learnings['highConfidenceThreshold'] = env_high_confidence_threshold
+    elif not file_has_high_confidence and legacy_distance_threshold is not None:
+        learnings['highConfidenceThreshold'] = legacy_distance_threshold
+
+    if env_possibly_relevant_threshold is not None:
+        learnings['possiblyRelevantThreshold'] = env_possibly_relevant_threshold
+    elif not file_has_possibly_relevant and legacy_distance_threshold is not None:
+        learnings['possiblyRelevantThreshold'] = legacy_distance_threshold
+
+    if env_keyword_boost_weight is not None:
+        learnings['keywordBoostWeight'] = env_keyword_boost_weight
+
+    default_learnings = defaults['learnings']
+
+    high_confidence = _coerce_float(learnings.get('highConfidenceThreshold'))
+    if high_confidence is None:
+        high_confidence = float(default_learnings['highConfidenceThreshold'])
+        print(
+            "Warning: Invalid learnings.highConfidenceThreshold; using default.",
+            file=sys.stderr,
+        )
+
+    possibly_relevant = _coerce_float(learnings.get('possiblyRelevantThreshold'))
+    if possibly_relevant is None:
+        possibly_relevant = float(default_learnings['possiblyRelevantThreshold'])
+        print(
+            "Warning: Invalid learnings.possiblyRelevantThreshold; using default.",
+            file=sys.stderr,
+        )
+
+    keyword_boost_weight = _coerce_float(learnings.get('keywordBoostWeight'))
+    if keyword_boost_weight is None:
+        keyword_boost_weight = float(default_learnings['keywordBoostWeight'])
+        print(
+            "Warning: Invalid learnings.keywordBoostWeight; using default.",
+            file=sys.stderr,
+        )
+
+    if possibly_relevant < high_confidence:
+        print(
+            (
+                "Warning: learnings.possiblyRelevantThreshold is lower than "
+                "learnings.highConfidenceThreshold; aligning both to "
+                "highConfidenceThreshold."
+            ),
+            file=sys.stderr,
+        )
+        possibly_relevant = high_confidence
+
+    learnings['highConfidenceThreshold'] = high_confidence
+    learnings['possiblyRelevantThreshold'] = possibly_relevant
+    learnings['keywordBoostWeight'] = keyword_boost_weight
 
     return result
 

--- a/plugins/compound-learning/tests/test_config_backward_compat.py
+++ b/plugins/compound-learning/tests/test_config_backward_compat.py
@@ -1,0 +1,155 @@
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+PLUGIN_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(PLUGIN_ROOT))
+
+import lib.db as db
+
+
+THRESHOLD_ENV_VARS = (
+    "LEARNINGS_DISTANCE_THRESHOLD",
+    "LEARNINGS_HIGH_CONFIDENCE_THRESHOLD",
+    "LEARNINGS_POSSIBLY_RELEVANT_THRESHOLD",
+    "LEARNINGS_KEYWORD_BOOST_WEIGHT",
+)
+
+
+def _write_config(tmp_path: Path, payload: dict) -> None:
+    config_dir = tmp_path / ".claude-plugin"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    (config_dir / "config.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _reset_threshold_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var_name in THRESHOLD_ENV_VARS:
+        monkeypatch.delenv(var_name, raising=False)
+
+
+def test_legacy_file_distance_threshold_maps_to_tiered_thresholds(tmp_path, monkeypatch):
+    _reset_threshold_env(monkeypatch)
+    _write_config(
+        tmp_path,
+        {
+            "learnings": {
+                "distanceThreshold": 0.61,
+            }
+        },
+    )
+    monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(tmp_path))
+
+    config = db.load_config()
+
+    assert config["learnings"]["highConfidenceThreshold"] == pytest.approx(0.61)
+    assert config["learnings"]["possiblyRelevantThreshold"] == pytest.approx(0.61)
+    assert config["learnings"]["keywordBoostWeight"] == pytest.approx(0.65)
+
+
+def test_new_file_threshold_keys_override_legacy_file_key(tmp_path, monkeypatch):
+    _reset_threshold_env(monkeypatch)
+    _write_config(
+        tmp_path,
+        {
+            "learnings": {
+                "distanceThreshold": 0.72,
+                "highConfidenceThreshold": 0.33,
+                "possiblyRelevantThreshold": 0.48,
+                "keywordBoostWeight": 0.77,
+            }
+        },
+    )
+    monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(tmp_path))
+
+    config = db.load_config()
+
+    assert config["learnings"]["highConfidenceThreshold"] == pytest.approx(0.33)
+    assert config["learnings"]["possiblyRelevantThreshold"] == pytest.approx(0.48)
+    assert config["learnings"]["keywordBoostWeight"] == pytest.approx(0.77)
+
+
+def test_legacy_env_distance_threshold_falls_back_when_new_keys_absent(tmp_path, monkeypatch):
+    _reset_threshold_env(monkeypatch)
+    _write_config(
+        tmp_path,
+        {
+            "learnings": {
+                "globalDir": "${HOME}/.projects/learnings",
+            }
+        },
+    )
+    monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(tmp_path))
+    monkeypatch.setenv("LEARNINGS_DISTANCE_THRESHOLD", "0.58")
+
+    config = db.load_config()
+
+    assert config["learnings"]["highConfidenceThreshold"] == pytest.approx(0.58)
+    assert config["learnings"]["possiblyRelevantThreshold"] == pytest.approx(0.58)
+
+
+def test_new_env_thresholds_override_legacy_env_and_file_values(tmp_path, monkeypatch):
+    _reset_threshold_env(monkeypatch)
+    _write_config(
+        tmp_path,
+        {
+            "learnings": {
+                "distanceThreshold": 0.66,
+                "highConfidenceThreshold": 0.31,
+                "possiblyRelevantThreshold": 0.45,
+                "keywordBoostWeight": 0.62,
+            }
+        },
+    )
+    monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(tmp_path))
+    monkeypatch.setenv("LEARNINGS_DISTANCE_THRESHOLD", "0.69")
+    monkeypatch.setenv("LEARNINGS_HIGH_CONFIDENCE_THRESHOLD", "0.27")
+    monkeypatch.setenv("LEARNINGS_POSSIBLY_RELEVANT_THRESHOLD", "0.41")
+    monkeypatch.setenv("LEARNINGS_KEYWORD_BOOST_WEIGHT", "0.84")
+
+    config = db.load_config()
+
+    assert config["learnings"]["highConfidenceThreshold"] == pytest.approx(0.27)
+    assert config["learnings"]["possiblyRelevantThreshold"] == pytest.approx(0.41)
+    assert config["learnings"]["keywordBoostWeight"] == pytest.approx(0.84)
+
+
+def test_legacy_env_distance_threshold_overrides_legacy_file_value(tmp_path, monkeypatch):
+    _reset_threshold_env(monkeypatch)
+    _write_config(
+        tmp_path,
+        {
+            "learnings": {
+                "distanceThreshold": 0.64,
+            }
+        },
+    )
+    monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(tmp_path))
+    monkeypatch.setenv("LEARNINGS_DISTANCE_THRESHOLD", "0.52")
+
+    config = db.load_config()
+
+    assert config["learnings"]["highConfidenceThreshold"] == pytest.approx(0.52)
+    assert config["learnings"]["possiblyRelevantThreshold"] == pytest.approx(0.52)
+
+
+def test_misordered_thresholds_are_aligned_with_warning(tmp_path, monkeypatch, capsys):
+    _reset_threshold_env(monkeypatch)
+    _write_config(
+        tmp_path,
+        {
+            "learnings": {
+                "highConfidenceThreshold": 0.50,
+                "possiblyRelevantThreshold": 0.45,
+            }
+        },
+    )
+    monkeypatch.setenv("CLAUDE_PLUGIN_ROOT", str(tmp_path))
+
+    config = db.load_config()
+    captured = capsys.readouterr()
+
+    assert config["learnings"]["highConfidenceThreshold"] == pytest.approx(0.50)
+    assert config["learnings"]["possiblyRelevantThreshold"] == pytest.approx(0.50)
+    assert "possiblyRelevantThreshold is lower" in captured.err


### PR DESCRIPTION
## Summary
- restore backward compatibility for threshold configuration by supporting legacy `distanceThreshold` and `LEARNINGS_DISTANCE_THRESHOLD` inputs
- add explicit numeric env parsing for `LEARNINGS_DISTANCE_THRESHOLD`, `LEARNINGS_HIGH_CONFIDENCE_THRESHOLD`, `LEARNINGS_POSSIBLY_RELEVANT_THRESHOLD`, and `LEARNINGS_KEYWORD_BOOST_WEIGHT` with invalid-value stderr warnings
- enforce threshold ordering guard in `load_config()` (`possiblyRelevantThreshold >= highConfidenceThreshold`) with warning + alignment
- add focused compatibility tests and update plugin config/docs to tiered keys while documenting legacy support

## Compatibility Matrix
| Scenario | Inputs | Expected precedence behavior | Verified |
|---|---|---|---|
| Legacy file only | `learnings.distanceThreshold` | mapped into tiered thresholds when new keys absent | yes (`test_legacy_file_distance_threshold_maps_to_tiered_thresholds`) |
| New file keys + legacy file key | `highConfidenceThreshold` / `possiblyRelevantThreshold` / `keywordBoostWeight` + `distanceThreshold` | new keys override legacy key | yes (`test_new_file_threshold_keys_override_legacy_file_key`) |
| Legacy env fallback | `LEARNINGS_DISTANCE_THRESHOLD` only | legacy env maps to tiered thresholds when new keys absent | yes (`test_legacy_env_distance_threshold_falls_back_when_new_keys_absent`) |
| New env override | new threshold env vars + legacy env/file values | new env vars override legacy env/file values | yes (`test_new_env_thresholds_override_legacy_env_and_file_values`) |
| Legacy env vs legacy file | both legacy env and file values present | `LEARNINGS_DISTANCE_THRESHOLD` overrides file `distanceThreshold` | yes (`test_legacy_env_distance_threshold_overrides_legacy_file_value`) |
| Misordered tiers | `possiblyRelevantThreshold < highConfidenceThreshold` | runtime aligns `possiblyRelevantThreshold` to `highConfidenceThreshold` and warns | yes (`test_misordered_thresholds_are_aligned_with_warning`) |

## Test Evidence
```bash
pytest plugins/compound-learning/tests/test_config_backward_compat.py plugins/compound-learning/tests/test_observability.py
```
- result: 10 passed

Attempted plan-specified command including `plugins/compound-learning/tests/test_test_gap_finder.py`, but that file is not present on this branch, so pytest reported path-not-found for that test target.

## Manual Smoke Check
Executed a `python3` config smoke snippet to validate `load_config()` precedence outcomes:
- legacy file only: `highConfidenceThreshold=0.62`, `possiblyRelevantThreshold=0.62`, `keywordBoostWeight=0.65`
- new env override: `highConfidenceThreshold=0.29`, `possiblyRelevantThreshold=0.43`, `keywordBoostWeight=0.81`