### PR TITLE
Add privacy policy consistency checker

### DIFF
--- a/plugins/compound-learning/PRIVACY_POLICY.md
+++ b/plugins/compound-learning/PRIVACY_POLICY.md
@@ -1,0 +1,35 @@
+# Compound Learning Privacy Policy
+
+This document defines privacy claims for the `compound-learning` plugin and maps each claim to either:
+
+- `automated` enforcement via `privacy-policy-claims.json` and `scripts/check-privacy-policy.py`
+- `manual_review` when static checks are not sufficient
+
+## Scope
+
+These claims cover only behavior in this repository's plugin code and default configuration.
+They do not guarantee upstream Claude CLI/service behavior, host OS controls, or third-party model routing.
+
+## Claims
+
+| Claim ID | Claim | Enforcement |
+| --- | --- | --- |
+| `CL-PRIV-001` | Default SQLite database location is local (`${HOME}/.claude/compound-learning.db`). | automated |
+| `CL-PRIV-002` | Observability logging is disabled by default. | automated |
+| `CL-PRIV-003` | Observability log default path is local (`~/.claude/plugins/compound-learning/observability.jsonl`). | automated |
+| `CL-PRIV-004` | Session dedupe state is stored as local `.seen` files under `~/.claude/plugins/compound-learning/sessions`, with 24-hour pruning. | automated |
+| `CL-PRIV-005` | `extract-learnings` and `auto-peek` hooks skip in subprocess mode (`CLAUDE_SUBPROCESS`) to avoid recursive hook processing. | automated |
+| `CL-PRIV-006` | Auto-extraction subprocess uses minimal declared Claude tool permissions: `Write,Bash(mkdir:*)`. | automated |
+| `CL-PRIV-007` | Hook activity logs are written to local filesystem paths under user home (with local fallback directories). | automated |
+| `CL-PRIV-900` | No additional external transport beyond configured Claude runtime can be guaranteed statically. | manual_review |
+| `CL-PRIV-901` | Learning content may include transcript-derived information; retention/access controls depend on local environment setup. | manual_review |
+
+## Verification
+
+Run:
+
+```bash
+python3 scripts/check-privacy-policy.py
+```
+
+The checker exits non-zero if any `automated` claim fails.

--- a/plugins/compound-learning/README.md
+++ b/plugins/compound-learning/README.md
@@ -2,6 +2,11 @@
 
 A learning compounding system for Claude Code that extracts and indexes knowledge from conversations using local SQLite-vec semantic search. No Docker required.
 
+## Privacy Policy
+
+- Privacy policy: [PRIVACY_POLICY.md](PRIVACY_POLICY.md)
+- Automated consistency checker: `python3 scripts/check-privacy-policy.py`
+
 ## Prerequisites
 
 - Python 3.x with pip
@@ -182,9 +187,9 @@ How it works:
 1. Hooks trigger `extract-learnings.sh` which invokes `claude -p` to analyze the transcript
 2. Claude reads the conversation transcript and identifies 0-3 meaningful learnings
 3. Learning files are written to the appropriate scope (global or repo)
-4. A session tracking file (`~/.claude/compound-processed-sessions`) prevents duplicate extraction
+4. Session tracking files (`~/.claude/plugins/compound-learning/sessions/*.seen`) prevent duplicate surfacing within a session window
 
-**Debug log:** `~/.claude/compound-hook-debug.log`
+**Debug log:** `~/.claude/plugins/compound-learning/activity.log`
 
 **Note:** Extraction uses minimal permissions (`Read`, `Write`, `Bash(mkdir:*)`) and skips trivial sessions (<20 transcript lines).
 

--- a/plugins/compound-learning/privacy-policy-claims.json
+++ b/plugins/compound-learning/privacy-policy-claims.json
@@ -1,0 +1,158 @@
+{
+  "version": 1,
+  "claims": [
+    {
+      "id": "CL-PRIV-001",
+      "title": "SQLite database default is local to user home",
+      "enforcement": "automated",
+      "statement": "Default SQLite DB path is ${HOME}/.claude/compound-learning.db.",
+      "checks": [
+        {
+          "type": "json_value",
+          "file": ".claude-plugin/config.json",
+          "path": "sqlite.dbPath",
+          "equals": "${HOME}/.claude/compound-learning.db"
+        },
+        {
+          "type": "contains",
+          "file": "lib/db.py",
+          "value": "os.path.join(home, '.claude', 'compound-learning.db')"
+        }
+      ]
+    },
+    {
+      "id": "CL-PRIV-002",
+      "title": "Observability is disabled by default",
+      "enforcement": "automated",
+      "statement": "Observability default enabled state is false.",
+      "checks": [
+        {
+          "type": "json_value",
+          "file": ".claude-plugin/config.json",
+          "path": "observability.enabled",
+          "equals": false
+        },
+        {
+          "type": "contains",
+          "file": "lib/db.py",
+          "value": "'enabled': False"
+        }
+      ]
+    },
+    {
+      "id": "CL-PRIV-003",
+      "title": "Observability logs default to local filesystem path",
+      "enforcement": "automated",
+      "statement": "Default observability log path is ~/.claude/plugins/compound-learning/observability.jsonl.",
+      "checks": [
+        {
+          "type": "json_value",
+          "file": ".claude-plugin/config.json",
+          "path": "observability.logPath",
+          "equals": "${HOME}/.claude/plugins/compound-learning/observability.jsonl"
+        },
+        {
+          "type": "contains",
+          "file": "lib/db.py",
+          "value": "os.path.join(home, '.claude', 'plugins', 'compound-learning', 'observability.jsonl')"
+        },
+        {
+          "type": "contains",
+          "file": "lib/observability.py",
+          "value": "~/.claude/plugins/compound-learning/observability.jsonl"
+        }
+      ]
+    },
+    {
+      "id": "CL-PRIV-004",
+      "title": "Session dedupe state uses local per-session files with 24h pruning",
+      "enforcement": "automated",
+      "statement": "Session dedupe state is stored in ~/.claude/plugins/compound-learning/sessions/*.seen and stale files are pruned after 24 hours.",
+      "checks": [
+        {
+          "type": "contains",
+          "file": "hooks/auto-peek.sh",
+          "value": "SESSIONS_DIR=\"$HOME/.claude/plugins/compound-learning/sessions\""
+        },
+        {
+          "type": "contains",
+          "file": "hooks/auto-peek.sh",
+          "value": "find \"$SESSIONS_DIR\" -name \"*.seen\" -mmin +1440 -delete"
+        },
+        {
+          "type": "contains",
+          "file": "hooks/auto-peek.sh",
+          "value": "SESSION_FILE=\"$SESSIONS_DIR/${SESSION_STATE_ID}.seen\""
+        }
+      ]
+    },
+    {
+      "id": "CL-PRIV-005",
+      "title": "Hooks guard against recursive subprocess execution",
+      "enforcement": "automated",
+      "statement": "extract-learnings and auto-peek skip execution when CLAUDE_SUBPROCESS is set.",
+      "checks": [
+        {
+          "type": "contains",
+          "file": "hooks/extract-learnings.sh",
+          "value": "if [ -n \"$CLAUDE_SUBPROCESS\" ]; then"
+        },
+        {
+          "type": "contains",
+          "file": "hooks/auto-peek.sh",
+          "value": "if [ -n \"$CLAUDE_SUBPROCESS\" ]; then"
+        }
+      ]
+    },
+    {
+      "id": "CL-PRIV-006",
+      "title": "Auto-extraction uses restricted declared tool permissions",
+      "enforcement": "automated",
+      "statement": "extract-learnings passes --allowedTools \"Write,Bash(mkdir:*)\" to claude -p.",
+      "checks": [
+        {
+          "type": "contains",
+          "file": "hooks/extract-learnings.sh",
+          "value": "--allowedTools \"Write,Bash(mkdir:*)\""
+        }
+      ]
+    },
+    {
+      "id": "CL-PRIV-007",
+      "title": "Hook activity log path is local",
+      "enforcement": "automated",
+      "statement": "Hook activity logs default to ~/.claude/plugins/compound-learning/activity.log with local fallback directories.",
+      "checks": [
+        {
+          "type": "contains",
+          "file": "hooks/observability.sh",
+          "value": "HOOK_LOG_DIR=\"$HOME/.claude/plugins/compound-learning\""
+        },
+        {
+          "type": "contains",
+          "file": "hooks/observability.sh",
+          "value": "HOOK_ACTIVITY_LOG=\"$HOOK_LOG_DIR/activity.log\""
+        },
+        {
+          "type": "contains",
+          "file": "hooks/observability.sh",
+          "value": "HOOK_LOG_DIR=\"/tmp/compound-learning-logs\""
+        }
+      ]
+    },
+    {
+      "id": "CL-PRIV-900",
+      "title": "External transport behavior requires runtime review",
+      "enforcement": "manual_review",
+      "statement": "This repository cannot statically prove runtime network routing behavior of claude subprocess calls.",
+      "manual_review_reason": "Requires runtime environment and provider/network review outside repository static analysis."
+    },
+    {
+      "id": "CL-PRIV-901",
+      "title": "Retention controls for generated learning content require operational review",
+      "enforcement": "manual_review",
+      "statement": "Local file retention and access controls depend on user host configuration and operational policy.",
+      "manual_review_reason": "Requires deployment-specific filesystem permissions and retention policy checks."
+    }
+  ]
+}

--- a/plugins/compound-learning/scripts/check-privacy-policy.py
+++ b/plugins/compound-learning/scripts/check-privacy-policy.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""Validate machine-readable privacy claims against repository files."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Tuple
+
+
+FLAG_MAP: Dict[str, re.RegexFlag] = {
+    "ASCII": re.ASCII,
+    "IGNORECASE": re.IGNORECASE,
+    "MULTILINE": re.MULTILINE,
+    "DOTALL": re.DOTALL,
+}
+
+
+def parse_args() -> argparse.Namespace:
+    script_path = Path(__file__).resolve()
+    plugin_root = script_path.parent.parent
+    parser = argparse.ArgumentParser(
+        description="Check compound-learning code/config consistency with privacy policy claims."
+    )
+    parser.add_argument(
+        "--plugin-root",
+        type=Path,
+        default=plugin_root,
+        help="Path to compound-learning plugin root (default: script-derived).",
+    )
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        default=plugin_root / "privacy-policy-claims.json",
+        help="Path to privacy claims manifest JSON.",
+    )
+    return parser.parse_args()
+
+
+def _format_path(path: Path) -> str:
+    try:
+        return str(path.resolve())
+    except OSError:
+        return str(path)
+
+
+def _read_text(path: Path, text_cache: Dict[Path, str]) -> str:
+    if path not in text_cache:
+        text_cache[path] = path.read_text(encoding="utf-8")
+    return text_cache[path]
+
+
+def _read_json(path: Path, json_cache: Dict[Path, Any]) -> Any:
+    if path not in json_cache:
+        json_cache[path] = json.loads(path.read_text(encoding="utf-8"))
+    return json_cache[path]
+
+
+def _json_lookup(payload: Any, dotted_path: str) -> Tuple[bool, Any]:
+    current = payload
+    for segment in dotted_path.split("."):
+        if isinstance(current, Mapping) and segment in current:
+            current = current[segment]
+            continue
+        if isinstance(current, list):
+            try:
+                idx = int(segment)
+            except ValueError:
+                return False, None
+            if idx < 0 or idx >= len(current):
+                return False, None
+            current = current[idx]
+            continue
+        return False, None
+    return True, current
+
+
+def _resolve_target(plugin_root: Path, relative_file: str) -> Path:
+    target = (plugin_root / relative_file).resolve()
+    try:
+        target.relative_to(plugin_root.resolve())
+    except ValueError:
+        raise ValueError(f"target file escapes plugin root: {relative_file}")
+    return target
+
+
+def _run_check(
+    check: Mapping[str, Any],
+    *,
+    plugin_root: Path,
+    text_cache: Dict[Path, str],
+    json_cache: Dict[Path, Any],
+) -> Tuple[bool, str]:
+    check_type = str(check.get("type", "")).strip()
+    relative_file = check.get("file")
+    if not isinstance(relative_file, str) or not relative_file:
+        return False, "missing required check field: file"
+
+    try:
+        target = _resolve_target(plugin_root, relative_file)
+    except ValueError as exc:
+        return False, str(exc)
+
+    if check_type == "file_exists":
+        return target.exists(), f"file does not exist: {relative_file}"
+
+    if not target.exists():
+        return False, f"target file not found: {relative_file}"
+
+    if check_type == "contains":
+        needle = check.get("value")
+        if not isinstance(needle, str):
+            return False, "contains check requires string field: value"
+        haystack = _read_text(target, text_cache)
+        if needle in haystack:
+            return True, f"contains matched in {relative_file}"
+        return False, f"expected string not found in {relative_file}: {needle!r}"
+
+    if check_type == "regex":
+        pattern = check.get("pattern")
+        if not isinstance(pattern, str):
+            return False, "regex check requires string field: pattern"
+
+        flags_value = 0
+        raw_flags = check.get("flags", [])
+        if raw_flags is None:
+            raw_flags = []
+        if not isinstance(raw_flags, list):
+            return False, "regex check field flags must be a list"
+        for raw in raw_flags:
+            if not isinstance(raw, str):
+                return False, "regex check flags must be strings"
+            flag_name = raw.strip().upper()
+            if flag_name not in FLAG_MAP:
+                return False, f"unsupported regex flag: {raw}"
+            flags_value |= FLAG_MAP[flag_name]
+
+        content = _read_text(target, text_cache)
+        if re.search(pattern, content, flags=flags_value):
+            return True, f"regex matched in {relative_file}"
+        return False, f"regex did not match in {relative_file}: {pattern!r}"
+
+    if check_type == "json_value":
+        dotted_path = check.get("path")
+        if not isinstance(dotted_path, str) or not dotted_path:
+            return False, "json_value check requires string field: path"
+        expected = check.get("equals")
+        payload = _read_json(target, json_cache)
+        found, actual = _json_lookup(payload, dotted_path)
+        if not found:
+            return False, f"json path not found in {relative_file}: {dotted_path}"
+        if actual == expected:
+            return True, f"json value matched in {relative_file}:{dotted_path}"
+        return (
+            False,
+            (
+                f"json value mismatch in {relative_file}:{dotted_path} "
+                f"(expected {expected!r}, found {actual!r})"
+            ),
+        )
+
+    return False, f"unsupported check type: {check_type!r}"
+
+
+def evaluate_claims(manifest_path: Path, plugin_root: Path) -> int:
+    try:
+        manifest_raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        print(f"ERROR: manifest file not found: {_format_path(manifest_path)}")
+        return 2
+    except json.JSONDecodeError as exc:
+        print(f"ERROR: failed to parse manifest JSON: {_format_path(manifest_path)}: {exc}")
+        return 2
+
+    claims = manifest_raw.get("claims")
+    if not isinstance(claims, list):
+        print("ERROR: manifest must contain a 'claims' list")
+        return 2
+
+    text_cache: Dict[Path, str] = {}
+    json_cache: Dict[Path, Any] = {}
+
+    automated_pass = 0
+    automated_fail = 0
+    manual_review = 0
+    errors: List[str] = []
+
+    print("Privacy Policy Consistency Report")
+    print(f"manifest: {_format_path(manifest_path)}")
+    print(f"plugin_root: {_format_path(plugin_root)}")
+    print("")
+
+    for claim in sorted(claims, key=lambda c: str(c.get("id", ""))):
+        claim_id = str(claim.get("id", "<missing-id>"))
+        title = str(claim.get("title", "")).strip() or "(untitled claim)"
+        enforcement = str(claim.get("enforcement", "")).strip()
+
+        if enforcement == "manual_review":
+            manual_review += 1
+            reason = str(claim.get("manual_review_reason", "")).strip()
+            print(f"[MANUAL] {claim_id}: {title}")
+            if reason:
+                print(f"  reason: {reason}")
+            continue
+
+        if enforcement != "automated":
+            automated_fail += 1
+            msg = f"claim has unsupported enforcement mode {enforcement!r}"
+            errors.append(f"{claim_id}: {msg}")
+            print(f"[FAIL] {claim_id}: {title}")
+            print(f"  reason: {msg}")
+            continue
+
+        checks = claim.get("checks")
+        if not isinstance(checks, list) or not checks:
+            automated_fail += 1
+            msg = "automated claim must define a non-empty checks list"
+            errors.append(f"{claim_id}: {msg}")
+            print(f"[FAIL] {claim_id}: {title}")
+            print(f"  reason: {msg}")
+            continue
+
+        check_failures: List[str] = []
+        for idx, raw_check in enumerate(checks, start=1):
+            if not isinstance(raw_check, Mapping):
+                check_failures.append(f"check {idx}: check entry must be an object")
+                continue
+            ok, detail = _run_check(
+                raw_check,
+                plugin_root=plugin_root,
+                text_cache=text_cache,
+                json_cache=json_cache,
+            )
+            if not ok:
+                check_failures.append(f"check {idx}: {detail}")
+
+        if check_failures:
+            automated_fail += 1
+            print(f"[FAIL] {claim_id}: {title}")
+            for failure in check_failures:
+                print(f"  reason: {failure}")
+                errors.append(f"{claim_id}: {failure}")
+        else:
+            automated_pass += 1
+            print(f"[PASS] {claim_id}: {title}")
+
+    total = automated_pass + automated_fail + manual_review
+    print("")
+    print(
+        "Summary: "
+        f"automated_pass={automated_pass} "
+        f"automated_fail={automated_fail} "
+        f"manual_review={manual_review} "
+        f"total={total}"
+    )
+
+    if automated_fail:
+        print("")
+        print("Automated claim mismatches detected:")
+        for item in errors:
+            print(f"- {item}")
+        return 1
+    return 0
+
+
+def main() -> int:
+    args = parse_args()
+    plugin_root = args.plugin_root.resolve()
+    manifest_path = args.manifest.resolve()
+    return evaluate_claims(manifest_path, plugin_root)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/compound-learning/tests/test_privacy_policy_consistency.py
+++ b/plugins/compound-learning/tests/test_privacy_policy_consistency.py
@@ -1,0 +1,63 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+PLUGIN_ROOT = Path(__file__).parent.parent
+CHECKER_SCRIPT = PLUGIN_ROOT / "scripts" / "check-privacy-policy.py"
+CLAIMS_MANIFEST = PLUGIN_ROOT / "privacy-policy-claims.json"
+
+
+def _run_checker(manifest_path: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(CHECKER_SCRIPT),
+            "--plugin-root",
+            str(PLUGIN_ROOT),
+            "--manifest",
+            str(manifest_path),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_privacy_policy_checker_passes_for_repository_baseline():
+    result = _run_checker(CLAIMS_MANIFEST)
+
+    assert result.returncode == 0, (
+        "checker should pass for repository baseline\n"
+        f"stdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )
+    assert "[PASS]" in result.stdout
+    assert "automated_fail=0" in result.stdout
+
+
+def test_privacy_policy_checker_fails_on_manifest_mismatch(tmp_path):
+    manifest = json.loads(CLAIMS_MANIFEST.read_text(encoding="utf-8"))
+
+    for claim in manifest.get("claims", []):
+        if claim.get("enforcement") == "automated":
+            claim["checks"] = [
+                {
+                    "type": "contains",
+                    "file": "README.md",
+                    "value": "THIS_SENTINEL_SHOULD_NOT_EXIST_IN_README",
+                }
+            ]
+            break
+    else:
+        raise AssertionError("expected at least one automated claim in manifest")
+
+    mismatch_manifest = tmp_path / "privacy-policy-claims.mismatch.json"
+    mismatch_manifest.write_text(json.dumps(manifest), encoding="utf-8")
+
+    result = _run_checker(mismatch_manifest)
+
+    assert result.returncode != 0
+    assert "[FAIL]" in result.stdout
+    assert "THIS_SENTINEL_SHOULD_NOT_EXIST_IN_README" in result.stdout


### PR DESCRIPTION
## Summary
- add `plugins/compound-learning/PRIVACY_POLICY.md` with explicit privacy claim IDs and automated/manual-review classification
- add `plugins/compound-learning/privacy-policy-claims.json` manifest for machine-checkable claims (defaults, local paths, hook subprocess guards, and logging behavior)
- add `plugins/compound-learning/scripts/check-privacy-policy.py` to evaluate claims and fail fast on automated mismatches
- add `plugins/compound-learning/tests/test_privacy_policy_consistency.py` for baseline-pass and forced-mismatch failure coverage
- update README privacy docs and correct session tracking/debug log path claims to match implementation

## Automatically enforced claims
- default local SQLite DB path
- observability default disabled and local default log path
- local session dedupe `.seen` path plus 24h pruning
- `CLAUDE_SUBPROCESS` guard in extraction/auto-peek hooks
- restricted extraction tool permissions (`Write,Bash(mkdir:*)`)
- local hook activity log paths

## Validation
- `python -m pytest plugins/compound-learning/tests/test_privacy_policy_consistency.py -v`
- `python -m pytest plugins/compound-learning/tests/test_config_backward_compat.py plugins/compound-learning/tests/test_observability.py -v`
- full `plugins/compound-learning/tests` run currently fails in `test_search_relevance.py` due local `transformers/torchvision` environment import errors unrelated to these changes
