### PR TITLE
Optimize compound-learning SessionStart bootstrap

### DIFF
--- a/plugins/compound-learning/README.md
+++ b/plugins/compound-learning/README.md
@@ -8,6 +8,7 @@ A learning compounding system for Claude Code that extracts and indexes knowledg
 - GitHub CLI (`gh`) - optional, required for `/pr-learnings`
 
 Python dependencies (`pysqlite3-binary`, `sqlite-vec`, `sentence-transformers`) are auto-installed on session start via the `SessionStart` hook.
+Runtime dependency declarations are tracked in `requirements-runtime.txt`.
 
 ## Installation
 
@@ -23,12 +24,30 @@ Python dependencies (`pysqlite3-binary`, `sqlite-vec`, `sentence-transformers`) 
 1. Clone or download this plugin to your Claude plugins directory
 2. Python dependencies install automatically on first session start, or install manually:
 ```bash
-pip install pysqlite3-binary sqlite-vec sentence-transformers
+pip install -r requirements-runtime.txt
 ```
 
 ### Post-Installation
 
 Run `/index-learnings` to build the index. The SQLite database is created automatically and the embedding model (~80MB) downloads on first use.
+
+## SessionStart Bootstrap
+
+`hooks/setup.sh` is manifest-driven and cache-aware:
+
+1. Reads runtime dependencies from `requirements-runtime.txt`
+2. Builds a cache key from Python version + manifest SHA256
+3. Skips dependency checks entirely when a matching warm stamp exists at `~/.claude/plugins/compound-learning/cache/`
+4. On cache miss, checks imports and installs only missing packages
+5. Writes a new stamp after successful validation/install
+
+Force a refresh when debugging stale environments:
+
+```bash
+LEARNINGS_SETUP_FORCE_REFRESH=true bash hooks/setup.sh
+```
+
+Equivalent legacy alias: `COMPOUND_LEARNING_SETUP_FORCE_REFRESH=true`.
 
 ## Configuration
 
@@ -250,6 +269,10 @@ Use topic + context: "authentication JWT refresh" not "implement login feature"
 
 **Hook activity log:**
 - Hook activity is logged to `~/.claude/plugins/compound-learning/activity.log`
+
+**Stale bootstrap cache or dependency drift:**
+- Force a refresh once: `LEARNINGS_SETUP_FORCE_REFRESH=true bash hooks/setup.sh`
+- Or remove cache stamps manually: `rm -f ~/.claude/plugins/compound-learning/cache/setup-*.stamp`
 
 **Observability log:**
 - Structured events are logged to `~/.claude/plugins/compound-learning/observability.jsonl` (or `LEARNINGS_OBS_LOG_PATH`)

--- a/plugins/compound-learning/hooks/hooks.json
+++ b/plugins/compound-learning/hooks/hooks.json
@@ -7,7 +7,7 @@
           {
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/setup.sh",
-            "timeout": 120000
+            "timeout": 60000
           }
         ]
       }

--- a/plugins/compound-learning/hooks/setup.sh
+++ b/plugins/compound-learning/hooks/setup.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 
 # Auto-install Python dependencies for compound-learning plugin
-# Runs on SessionStart to ensure deps are ready before other hooks fire
-# Idempotent: skips pip if all packages already importable
-# Exits 0 always to avoid blocking session start
+# Runs on SessionStart to ensure deps are ready before other hooks fire.
+# Exits 0 always to avoid blocking session start.
 
 HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$HOOK_DIR/observability.sh" || exit 0
@@ -13,6 +12,10 @@ SESSION_ID="${CLAUDE_SESSION_ID:-}"
 hook_set_session_context "$SESSION_ID"
 HOOK_OUTCOME="success"
 HOOK_OUTCOME_MESSAGE=""
+
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$HOOK_DIR/.." && pwd)}"
+MANIFEST_PATH="$PLUGIN_ROOT/requirements-runtime.txt"
+FORCE_REFRESH_RAW="${LEARNINGS_SETUP_FORCE_REFRESH:-${COMPOUND_LEARNING_SETUP_FORCE_REFRESH:-0}}"
 
 setup_hook_finalize() {
   local duration_ms
@@ -34,19 +37,236 @@ trap setup_hook_finalize EXIT
 
 hook_obs_event "info" "hook_start" "start" --session-id "$SESSION_ID"
 
-# Quick check: can we import all required packages?
-if python3 -c "
-import importlib.util, sys
-for pkg in ['pysqlite3', 'sqlite_vec', 'sentence_transformers']:
-    if importlib.util.find_spec(pkg) is None:
-        sys.exit(1)
-" 2>/dev/null; then
+declare -a REQUIREMENTS
+
+is_truthy() {
+  case "${1:-}" in
+    1|[Tt][Rr][Uu][Ee]|[Yy][Ee][Ss]|[Oo][Nn]) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+trim_line() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "$value"
+}
+
+requirement_to_import() {
+  local requirement="$1"
+  local package="$requirement"
+
+  package="${package%%;*}"
+  package="${package%%\[*}"
+  package="${package%%==*}"
+  package="${package%%~=*}"
+  package="${package%%!=*}"
+  package="${package%%<=*}"
+  package="${package%%>=*}"
+  package="${package%%<*}"
+  package="${package%%>*}"
+  package="$(trim_line "$package")"
+
+  case "$package" in
+    pysqlite3-binary) echo "pysqlite3" ;;
+    sqlite-vec) echo "sqlite_vec" ;;
+    sentence-transformers) echo "sentence_transformers" ;;
+    *) echo "${package//-/_}" ;;
+  esac
+}
+
+load_manifest_requirements() {
+  REQUIREMENTS=()
+
+  if [ ! -f "$MANIFEST_PATH" ]; then
+    return 1
+  fi
+
+  while IFS= read -r raw_line || [ -n "$raw_line" ]; do
+    raw_line="${raw_line%$'\r'}"
+    local line="${raw_line%%#*}"
+    line="$(trim_line "$line")"
+    [ -z "$line" ] && continue
+    REQUIREMENTS+=("$line")
+  done < "$MANIFEST_PATH"
+
+  [ "${#REQUIREMENTS[@]}" -gt 0 ]
+}
+
+manifest_checksum() {
+  local file_path="$1"
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$file_path" | awk '{print $1}'
+    return
+  fi
+
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$file_path" | awk '{print $1}'
+    return
+  fi
+
+  python3 - "$file_path" <<'PY'
+import hashlib
+import pathlib
+import sys
+
+payload = pathlib.Path(sys.argv[1]).read_bytes()
+print(hashlib.sha256(payload).hexdigest())
+PY
+}
+
+write_cache_stamp() {
+  mkdir -p "$CACHE_DIR" 2>/dev/null || return 1
+
+  {
+    printf 'python_version=%s\n' "$PYTHON_VERSION"
+    printf 'manifest_sha256=%s\n' "$MANIFEST_SHA256"
+    printf 'generated_at=%s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+  } > "$STAMP_FILE" 2>/dev/null || return 1
+
+  find "$CACHE_DIR" -maxdepth 1 -type f -name 'setup-*.stamp' ! -name "$(basename "$STAMP_FILE")" -delete 2>/dev/null || true
+  return 0
+}
+
+if ! command -v python3 >/dev/null 2>&1; then
+  hook_log_activity "[setup] python3 not found; skipping dependency bootstrap"
+  HOOK_OUTCOME="error"
+  HOOK_OUTCOME_MESSAGE="python3 not found"
+  hook_obs_event "error" "dependency_check" "failure" \
+    --session-id "$SESSION_ID" \
+    --message "python3 not found"
+  exit 0
+fi
+
+declare -a PIP_COMMAND
+if command -v pip >/dev/null 2>&1; then
+  PIP_COMMAND=(pip)
+elif python3 -m pip --version >/dev/null 2>&1; then
+  PIP_COMMAND=(python3 -m pip)
+else
+  hook_log_activity "[setup] pip not found; skipping dependency bootstrap"
+  HOOK_OUTCOME="error"
+  HOOK_OUTCOME_MESSAGE="pip not found"
+  hook_obs_event "error" "dependency_check" "failure" \
+    --session-id "$SESSION_ID" \
+    --message "pip not found"
+  exit 0
+fi
+
+if ! load_manifest_requirements; then
+  hook_log_activity "[setup] Missing or empty requirements manifest at $MANIFEST_PATH"
+  HOOK_OUTCOME="error"
+  HOOK_OUTCOME_MESSAGE="Missing requirements-runtime.txt"
+  hook_obs_event "error" "dependency_manifest" "failure" \
+    --session-id "$SESSION_ID" \
+    --message "Missing or empty requirements manifest" \
+    --counts-json '{"total_packages":0}'
+  exit 0
+fi
+
+hook_obs_event "info" "dependency_manifest" "loaded" \
+  --session-id "$SESSION_ID" \
+  --counts-json "{\"total_packages\":${#REQUIREMENTS[@]}}"
+
+PYTHON_VERSION="$(python3 - <<'PY'
+import sys
+print(f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}")
+PY
+)"
+MANIFEST_SHA256="$(manifest_checksum "$MANIFEST_PATH")"
+CACHE_DIR="$HOOK_LOG_DIR/cache"
+CACHE_KEY="${PYTHON_VERSION}_${MANIFEST_SHA256}"
+STAMP_FILE="$CACHE_DIR/setup-${CACHE_KEY}.stamp"
+
+FORCE_REFRESH=0
+if is_truthy "$FORCE_REFRESH_RAW"; then
+  FORCE_REFRESH=1
+fi
+
+if [ "$FORCE_REFRESH" -eq 1 ]; then
+  hook_log_activity "[setup] Force-refresh requested; bypassing cache stamp"
+  hook_obs_event "info" "dependency_cache" "bypass" \
+    --session-id "$SESSION_ID" \
+    --message "force refresh requested"
+elif [ -f "$STAMP_FILE" ]; then
+  hook_obs_event "info" "dependency_cache" "hit" \
+    --session-id "$SESSION_ID" \
+    --counts-json '{"cache_hit":1}'
+  HOOK_OUTCOME="skipped"
+  HOOK_OUTCOME_MESSAGE="Dependency cache hit"
+  hook_obs_event "info" "skip_reason" "skipped" \
+    --session-id "$SESSION_ID" \
+    --message "dependency cache hit"
+  exit 0
+else
+  hook_obs_event "info" "dependency_cache" "miss" \
+    --session-id "$SESSION_ID" \
+    --counts-json '{"cache_hit":0}'
+fi
+
+declare -a IMPORT_NAMES
+IMPORT_NAMES=()
+for requirement in "${REQUIREMENTS[@]}"; do
+  IMPORT_NAMES+=("$(requirement_to_import "$requirement")")
+done
+
+missing_output="$(python3 - "${IMPORT_NAMES[@]}" <<'PY'
+import importlib.util
+import sys
+
+for module_name in sys.argv[1:]:
+    if importlib.util.find_spec(module_name) is None:
+        print(module_name)
+PY
+)"
+missing_check_exit=$?
+
+if [ "$missing_check_exit" -ne 0 ]; then
+  hook_log_activity "[setup] Python import check failed (exit $missing_check_exit)"
+  HOOK_OUTCOME="error"
+  HOOK_OUTCOME_MESSAGE="Python import check failed (exit $missing_check_exit)"
+  hook_obs_event "error" "subprocess_exit" "failure" \
+    --session-id "$SESSION_ID" \
+    --counts-json "{\"command\":\"python_import_check\",\"exit_code\":$missing_check_exit}"
+  exit 0
+fi
+
+declare -a MISSING_IMPORTS
+MISSING_IMPORTS=()
+if [ -n "$missing_output" ]; then
+  while IFS= read -r module_name; do
+    [ -n "$module_name" ] && MISSING_IMPORTS+=("$module_name")
+  done <<< "$missing_output"
+fi
+
+declare -a MISSING_REQUIREMENTS
+MISSING_REQUIREMENTS=()
+for idx in "${!IMPORT_NAMES[@]}"; do
+  module_name="${IMPORT_NAMES[$idx]}"
+  for missing_module in "${MISSING_IMPORTS[@]}"; do
+    if [ "$module_name" = "$missing_module" ]; then
+      MISSING_REQUIREMENTS+=("${REQUIREMENTS[$idx]}")
+      break
+    fi
+  done
+done
+
+if [ "${#MISSING_REQUIREMENTS[@]}" -eq 0 ]; then
   hook_obs_event "info" "dependency_check" "success" \
     --session-id "$SESSION_ID" \
-    --counts-json '{"missing_packages":0}'
+    --counts-json "{\"missing_packages\":0,\"total_packages\":${#REQUIREMENTS[@]}}"
   hook_obs_event "info" "subprocess_exit" "success" \
     --session-id "$SESSION_ID" \
     --counts-json '{"command":"python_import_check","exit_code":0}'
+
+  if write_cache_stamp; then
+    hook_log_activity "[setup] Dependency check passed; cache stamp updated"
+  else
+    hook_log_activity "[setup] Dependency check passed; failed to write cache stamp"
+  fi
+
   HOOK_OUTCOME="skipped"
   HOOK_OUTCOME_MESSAGE="Dependencies already installed"
   hook_obs_event "info" "skip_reason" "skipped" \
@@ -59,17 +279,30 @@ hook_obs_event "warn" "subprocess_exit" "failure" \
   --session-id "$SESSION_ID" \
   --counts-json '{"command":"python_import_check","exit_code":1}'
 hook_obs_event "info" "dependency_check" "missing" \
-  --session-id "$SESSION_ID"
-hook_log_activity "[setup] Missing Python dependencies, installing..."
+  --session-id "$SESSION_ID" \
+  --counts-json "{\"missing_packages\":${#MISSING_REQUIREMENTS[@]},\"total_packages\":${#REQUIREMENTS[@]}}"
 
-# Install all required packages quietly
-if pip install --quiet pysqlite3-binary sqlite-vec sentence-transformers 2>>"$HOOK_ACTIVITY_LOG"; then
+missing_csv="$(IFS=,; echo "${MISSING_REQUIREMENTS[*]}")"
+hook_log_activity "[setup] Missing Python dependencies (${missing_csv}); installing only missing packages"
+
+if "${PIP_COMMAND[@]}" install --quiet --disable-pip-version-check "${MISSING_REQUIREMENTS[@]}" 2>>"$HOOK_ACTIVITY_LOG"; then
   hook_log_activity "[setup] Python dependencies installed successfully"
   hook_obs_event "info" "subprocess_exit" "success" \
     --session-id "$SESSION_ID" \
     --counts-json '{"command":"pip_install","exit_code":0}'
+
+  if write_cache_stamp; then
+    hook_obs_event "info" "dependency_cache" "write" \
+      --session-id "$SESSION_ID" \
+      --counts-json '{"cache_stamp_written":1}'
+  else
+    hook_log_activity "[setup] Failed to write cache stamp after install"
+    hook_obs_event "warn" "dependency_cache" "write_failed" \
+      --session-id "$SESSION_ID"
+  fi
+
   HOOK_OUTCOME="success"
-  HOOK_OUTCOME_MESSAGE="Dependencies installed successfully"
+  HOOK_OUTCOME_MESSAGE="Installed missing dependencies"
 else
   pip_exit=$?
   hook_log_activity "[setup] pip install failed (exit $pip_exit), plugin may not work correctly"

--- a/plugins/compound-learning/requirements-runtime.txt
+++ b/plugins/compound-learning/requirements-runtime.txt
@@ -1,0 +1,4 @@
+# Runtime Python dependencies for compound-learning SessionStart bootstrap.
+pysqlite3-binary
+sqlite-vec
+sentence-transformers

--- a/plugins/compound-learning/tests/test_setup_hook_cache.py
+++ b/plugins/compound-learning/tests/test_setup_hook_cache.py
@@ -1,0 +1,136 @@
+import os
+import subprocess
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+PLUGIN_ROOT = Path(__file__).parent.parent
+SETUP_SCRIPT = PLUGIN_ROOT / "hooks" / "setup.sh"
+
+
+def _write_runtime_manifest(plugin_root: Path, requirements: List[str]) -> None:
+    plugin_root.mkdir(parents=True, exist_ok=True)
+    payload = "\n".join(requirements) + "\n"
+    (plugin_root / "requirements-runtime.txt").write_text(payload, encoding="utf-8")
+
+
+def _write_fake_pip(bin_dir: Path) -> None:
+    pip_path = bin_dir / "pip"
+    pip_path.write_text(
+        """#!/bin/bash
+set -euo pipefail
+
+printf '%s\\n' "$*" >> "${PIP_LOG}"
+for arg in "$@"; do
+  case "$arg" in
+    alpha-pkg|beta-pkg|gamma-pkg)
+      touch "${MODULE_DIR}/${arg//-/_}.py"
+      ;;
+  esac
+done
+""",
+        encoding="utf-8",
+    )
+    pip_path.chmod(0o755)
+
+
+def _build_env(tmp_path: Path, plugin_root: Path, module_dir: Path, bin_dir: Path) -> Tuple[Dict[str, str], Path, Path]:
+    home_dir = tmp_path / "home"
+    home_dir.mkdir(parents=True, exist_ok=True)
+    pip_log = tmp_path / "pip.log"
+
+    env = os.environ.copy()
+    env["CLAUDE_PLUGIN_ROOT"] = str(plugin_root)
+    env["HOME"] = str(home_dir)
+    env["PIP_LOG"] = str(pip_log)
+    env["MODULE_DIR"] = str(module_dir)
+    env["LEARNINGS_OBS_ENABLED"] = "false"
+    env["PATH"] = f"{bin_dir}:{env.get('PATH', '')}"
+
+    existing_pythonpath = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = f"{module_dir}:{existing_pythonpath}" if existing_pythonpath else str(module_dir)
+
+    return env, home_dir, pip_log
+
+
+def _run_setup(env: Dict[str, str]) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", str(SETUP_SCRIPT)],
+        capture_output=True,
+        check=False,
+        env=env,
+        text=True,
+    )
+
+
+def _cache_stamp_files(home_dir: Path) -> List[Path]:
+    cache_dir = home_dir / ".claude" / "plugins" / "compound-learning" / "cache"
+    return sorted(cache_dir.glob("setup-*.stamp")) if cache_dir.exists() else []
+
+
+def _read_pip_calls(pip_log: Path) -> List[str]:
+    if not pip_log.exists():
+        return []
+    return [line for line in pip_log.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def test_setup_installs_only_missing_packages_and_reuses_cache_stamp(tmp_path):
+    plugin_root = tmp_path / "plugin"
+    module_dir = tmp_path / "modules"
+    bin_dir = tmp_path / "bin"
+    module_dir.mkdir(parents=True, exist_ok=True)
+    bin_dir.mkdir(parents=True, exist_ok=True)
+
+    _write_runtime_manifest(plugin_root, ["alpha-pkg", "beta-pkg"])
+    (module_dir / "alpha_pkg.py").write_text("ALPHA = True\n", encoding="utf-8")
+    _write_fake_pip(bin_dir)
+
+    env, home_dir, pip_log = _build_env(tmp_path, plugin_root, module_dir, bin_dir)
+
+    first_run = _run_setup(env)
+    assert first_run.returncode == 0
+
+    first_calls = _read_pip_calls(pip_log)
+    assert len(first_calls) == 1
+    assert "beta-pkg" in first_calls[0]
+    assert "alpha-pkg" not in first_calls[0]
+    assert len(_cache_stamp_files(home_dir)) == 1
+
+    (module_dir / "beta_pkg.py").unlink(missing_ok=True)
+
+    second_run = _run_setup(env)
+    assert second_run.returncode == 0
+
+    second_calls = _read_pip_calls(pip_log)
+    assert len(second_calls) == 1
+
+
+def test_setup_cache_invalidates_when_manifest_checksum_changes(tmp_path):
+    plugin_root = tmp_path / "plugin"
+    module_dir = tmp_path / "modules"
+    bin_dir = tmp_path / "bin"
+    module_dir.mkdir(parents=True, exist_ok=True)
+    bin_dir.mkdir(parents=True, exist_ok=True)
+
+    _write_runtime_manifest(plugin_root, ["alpha-pkg", "beta-pkg"])
+    (module_dir / "alpha_pkg.py").write_text("ALPHA = True\n", encoding="utf-8")
+    (module_dir / "beta_pkg.py").write_text("BETA = True\n", encoding="utf-8")
+    _write_fake_pip(bin_dir)
+
+    env, home_dir, pip_log = _build_env(tmp_path, plugin_root, module_dir, bin_dir)
+
+    warm_run = _run_setup(env)
+    assert warm_run.returncode == 0
+    assert _read_pip_calls(pip_log) == []
+    assert len(_cache_stamp_files(home_dir)) == 1
+
+    _write_runtime_manifest(plugin_root, ["alpha-pkg", "beta-pkg", "gamma-pkg"])
+
+    invalidate_run = _run_setup(env)
+    assert invalidate_run.returncode == 0
+
+    calls = _read_pip_calls(pip_log)
+    assert len(calls) == 1
+    assert "gamma-pkg" in calls[0]
+    assert "alpha-pkg" not in calls[0]
+    assert "beta-pkg" not in calls[0]
+    assert len(_cache_stamp_files(home_dir)) == 1


### PR DESCRIPTION
## Scope
Treat "build" as compound-learning plugin bootstrap on SessionStart, since this repo has no conventional webpack/vite/cargo build pipeline.

## What changed
- Added runtime dependency manifest: `plugins/compound-learning/requirements-runtime.txt`.
- Refactored `plugins/compound-learning/hooks/setup.sh` to:
  - read dependencies from manifest
  - map requirements to import names
  - detect missing deps individually
  - install only missing packages
  - maintain a deterministic warm-cache stamp keyed by Python version + manifest SHA256
  - support force-refresh via `LEARNINGS_SETUP_FORCE_REFRESH=true` (legacy alias supported)
- Tuned SessionStart hook timeout in `plugins/compound-learning/hooks/hooks.json` from 120000 -> 60000.
- Updated `plugins/compound-learning/README.md` with bootstrap/cache flow and troubleshooting instructions.
- Added tests: `plugins/compound-learning/tests/test_setup_hook_cache.py` for incremental install + cache invalidation behavior.

## Timing data
Baseline (pre-change, same setup.sh invocation harness):
- Warm path (dependencies present): **30.80 ms**
- Partial-missing path (simulated missing module): **629.97 ms**

After optimization:
- Warm first run (cache miss + check): **55.23 ms**
- Warm cache-hit run (stamp present): **32.96 ms**
- Partial-missing path (fresh cache, simulated missing module): **551.21 ms**

## Validation
- `bash -n plugins/compound-learning/hooks/setup.sh`
- `pytest -q plugins/compound-learning/tests/test_setup_hook_cache.py plugins/compound-learning/tests/test_config_backward_compat.py`
