### PR TITLE
chore: fix ruff lint issues in compound-learning

### DIFF
--- a/plugins/compound-learning/lib/db.py
+++ b/plugins/compound-learning/lib/db.py
@@ -12,6 +12,8 @@ import threading
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional
 
+import lib.observability as observability
+
 try:
     import sqlite3
     _test_conn = sqlite3.connect(':memory:')
@@ -29,9 +31,6 @@ except AttributeError:
 
 _model = None
 _model_lock = threading.Lock()
-
-
-import lib.observability as observability
 
 
 def _parse_bool(value: Any) -> bool | None:

--- a/plugins/compound-learning/lib/observability.py
+++ b/plugins/compound-learning/lib/observability.py
@@ -15,7 +15,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, Iterable, Iterator, Mapping, MutableMapping, Optional
+from typing import Any, Dict, Iterator, Mapping, MutableMapping, Optional
 
 try:
     import fcntl

--- a/plugins/compound-learning/scripts/backfill-topics.py
+++ b/plugins/compound-learning/scripts/backfill-topics.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# ruff: noqa: E402
 """
 Backfill missing **Topic:** fields in learning markdown files.
 

--- a/plugins/compound-learning/scripts/check-privacy-policy.py
+++ b/plugins/compound-learning/scripts/check-privacy-policy.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import argparse
 import json
 import re
-import sys
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Tuple
 

--- a/plugins/compound-learning/scripts/detect-knowledge-silos.py
+++ b/plugins/compound-learning/scripts/detect-knowledge-silos.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# ruff: noqa: E402
 """Detect knowledge silo concentration risk from indexed learnings."""
 
 from __future__ import annotations

--- a/plugins/compound-learning/scripts/search-learnings.py
+++ b/plugins/compound-learning/scripts/search-learnings.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# ruff: noqa: E402
 """
 Search learnings in SQLite with distance threshold filtering.
 Filters results before outputting to avoid context pollution.

--- a/plugins/compound-learning/skills/consolidate-actions/consolidate-actions.py
+++ b/plugins/compound-learning/skills/consolidate-actions/consolidate-actions.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# ruff: noqa: E402
 """
 Execute consolidation actions: merge, archive, delete, rescope, get.
 All destructive operations create backups first.
@@ -293,7 +294,7 @@ def action_merge(ids: List[str], name: str, config: Dict[str, Any],
 
         # Build structured merged content
         merged_content = f"# {name.replace('-', ' ').title()}\n\n"
-        merged_content += f"**Type:** pattern\n"
+        merged_content += "**Type:** pattern\n"
         merged_content += f"**Topic:** {merged_topic}\n"
         merged_content += f"**Tags:** {merged_tags}\n\n"
         merged_content += f"*Merged from {len(contents)} learnings on {date_str}*\n\n"

--- a/plugins/compound-learning/skills/consolidate-discovery/consolidate-discovery.py
+++ b/plugins/compound-learning/skills/consolidate-discovery/consolidate-discovery.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# ruff: noqa: E402
 """
 Discover consolidation candidates in SQLite.
 Returns compact output to avoid token bloat.

--- a/plugins/compound-learning/skills/index-learnings/index-learnings.py
+++ b/plugins/compound-learning/skills/index-learnings/index-learnings.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# ruff: noqa: E402
 """
 Index all learning markdown files into SQLite + sqlite-vec.
 Generates a manifest summarizing learnings by topic for CLAUDE.md integration.
@@ -178,7 +179,7 @@ def generate_manifest(manifest_data: Dict[str, List[Dict[str, Any]]], config: Di
 def _format_section(title: str, learnings: List[Dict[str, Any]]) -> List[str]:
     """Format a manifest section."""
     total = len(learnings)
-    gotchas = sum(1 for l in learnings if l.get('is_gotcha'))
+    gotchas = sum(1 for learning in learnings if learning.get('is_gotcha'))
 
     lines = []
     if gotchas > 0:
@@ -190,12 +191,12 @@ def _format_section(title: str, learnings: List[Dict[str, Any]]) -> List[str]:
     # Aggregate by topic
     topics: Dict[str, Dict] = defaultdict(lambda: {'count': 0, 'keywords': defaultdict(int), 'gotchas': 0})
 
-    for l in learnings:
-        topic = l['topic']
+    for learning in learnings:
+        topic = learning['topic']
         topics[topic]['count'] += 1
-        if l.get('is_gotcha'):
+        if learning.get('is_gotcha'):
             topics[topic]['gotchas'] += 1
-        for kw in l.get('keywords', []):
+        for kw in learning.get('keywords', []):
             topics[topic]['keywords'][kw] += 1
 
     # Table sorted by count
@@ -278,7 +279,7 @@ def index_learning_files():
     print("Opening database...")
     try:
         conn = db.get_connection(config)
-        print(f"[OK] Database ready")
+        print("[OK] Database ready")
     except Exception as e:
         logger.emit(
             'index_pipeline',

--- a/plugins/compound-learning/tests/test_config_backward_compat.py
+++ b/plugins/compound-learning/tests/test_config_backward_compat.py
@@ -1,3 +1,4 @@
+# ruff: noqa: E402
 import json
 import sys
 from pathlib import Path

--- a/plugins/compound-learning/tests/test_observability.py
+++ b/plugins/compound-learning/tests/test_observability.py
@@ -1,3 +1,4 @@
+# ruff: noqa: E402
 import importlib.util
 import json
 import sys

--- a/plugins/compound-learning/tests/test_search_relevance.py
+++ b/plugins/compound-learning/tests/test_search_relevance.py
@@ -5,14 +5,11 @@ These tests exercise the full search pipeline: real embeddings (all-MiniLM-L6-v2
 real SQLite/sqlite-vec/fts5, real indexing, and real reranking logic.
 No internal modules are mocked.
 """
+# ruff: noqa: E402
 
-import json
-import os
 import sys
-import tempfile
-import uuid
 from pathlib import Path
-from typing import Any, Dict, List, Set
+from typing import Any, Dict, List
 
 import pytest
 
@@ -205,7 +202,7 @@ def test_relevant_results_ranked_above_irrelevant(tmp_db):
         f"Expected PDF learning in results but got ids: {all_ids}"
     )
     assert GRAFANA_LEARNING[0] not in all_ids, (
-        f"Grafana learning should be excluded (zero keyword overlap with 'slash command pdf layout')"
+        "Grafana learning should be excluded (zero keyword overlap with 'slash command pdf layout')"
     )
 
 
@@ -366,7 +363,6 @@ def test_fts5_boost_helps_stemmed_matches(tmp_db):
 
     stem_raw = next((r for r in raw if r["id"] == stem_doc_id), None)
     assert stem_raw is not None, "stem doc not found in raw KNN results"
-    original_distance = stem_raw["distance"]
 
     # Rerank with FTS5 boost
     reranked_with_fts = hybrid_rerank(
@@ -389,7 +385,7 @@ def test_fts5_boost_helps_stemmed_matches(tmp_db):
         f"FTS5 boost should lower distance: with={with_fts['distance']} without={without_fts['distance']}"
     )
     assert abs(with_fts["distance"] - (without_fts["distance"] - 0.05)) < 0.001, (
-        f"Expected 0.05 reduction from FTS5 boost"
+        "Expected 0.05 reduction from FTS5 boost"
     )
 
 


### PR DESCRIPTION
## Summary
- fixed Ruff import-order issue in `plugins/compound-learning/lib/db.py` by moving `lib.observability` into the module import block
- applied targeted `# ruff: noqa: E402` file directives where runtime `sys.path` bootstrapping is intentional (`scripts/`, `skills/`, and selected tests)
- cleaned remaining lint/style issues: removed unused imports, removed redundant f-string prefixes, renamed ambiguous loop variables in `skills/index-learnings/index-learnings.py`, and removed one unused local in `test_search_relevance.py`

## Manual exceptions
- `E402` is intentionally suppressed only in files that modify `sys.path` before importing plugin-local modules

## Verification
- `ruff check .` (pass)
- `pytest plugins/compound-learning/tests` (21 passed, 8 skipped)