### PR TITLE
Skill grooming: normalize skill triggers and anchored script paths

### DIFF
--- a/plugins/compound-learning/commands/consolidate-learnings.md
+++ b/plugins/compound-learning/commands/consolidate-learnings.md
@@ -70,7 +70,7 @@ Approve this plan? (You can request modifications first)
 ```
 
 **Important for report:**
-- Use `consolidate-actions.py get` to fetch content if needed to understand WHY files should be merged
+- Use `python3 [plugin-path]/skills/consolidate-actions/consolidate-actions.py get --ids=...` to fetch content if needed to understand WHY files should be merged
 - Group name should be descriptive (e.g., "jwt-authentication", "helm-deployment-patterns")
 - **CRITICAL: Deletions must EXCLUDE files that appear in any merge group** - those get deleted automatically by the merge operation
 - Only list truly orphaned outdated files in the Deletions section
@@ -85,10 +85,10 @@ After user approval, launch sub-agents in parallel:
 Each sub-agent runs:
 ```bash
 # Merge sub-agent
-python3 consolidate-actions.py merge --ids=id1,id2 --name=group-name
+python3 [plugin-path]/skills/consolidate-actions/consolidate-actions.py merge --ids=id1,id2 --name=group-name
 
 # Deletion sub-agent
-python3 consolidate-actions.py delete --ids=id1,id2,id3
+python3 [plugin-path]/skills/consolidate-actions/consolidate-actions.py delete --ids=id1,id2,id3
 ```
 
 ### Phase 4: Report Results

--- a/plugins/compound-learning/skills/consolidate-actions/SKILL.md
+++ b/plugins/compound-learning/skills/consolidate-actions/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: consolidate-actions
-description: Execute consolidation actions (merge, archive, delete, rescope, get)
+description: Execute approved consolidation actions (merge, archive, delete, rescope, get). Use after review and user approval.
 ---
 
 # Consolidate Actions
@@ -11,26 +11,28 @@ Execute consolidation operations on learnings. All destructive operations create
 
 ```bash
 # Fetch full content for review
-python3 consolidate-actions.py get --ids=id1,id2
+python3 [plugin-path]/skills/consolidate-actions/consolidate-actions.py get --ids=id1,id2
 
 # Delete with backup
-python3 consolidate-actions.py delete --ids=id1,id2
+python3 [plugin-path]/skills/consolidate-actions/consolidate-actions.py delete --ids=id1,id2
 
 # Move to archive
-python3 consolidate-actions.py archive --ids=id1,id2
+python3 [plugin-path]/skills/consolidate-actions/consolidate-actions.py archive --ids=id1,id2
 
 # Change scope (repo -> global)
-python3 consolidate-actions.py rescope --id=abc123 --scope=global
+python3 [plugin-path]/skills/consolidate-actions/consolidate-actions.py rescope --id=abc123 --scope=global
 
 # Merge multiple into one
-python3 consolidate-actions.py merge --ids=id1,id2,id3 --name=jwt-patterns
+python3 [plugin-path]/skills/consolidate-actions/consolidate-actions.py merge --ids=id1,id2,id3 --name=jwt-patterns
 
 # Merge with explicit output directory (overrides scope logic)
-python3 consolidate-actions.py merge --ids=id1,id2 --name=patterns --output-dir=/path/to/repo/.projects/learnings/
+python3 [plugin-path]/skills/consolidate-actions/consolidate-actions.py merge --ids=id1,id2 --name=patterns --output-dir=/absolute/path/to/repo/.projects/learnings
 
 # Dry run (show what would happen)
-python3 consolidate-actions.py merge --ids=id1,id2 --name=patterns --dry-run
+python3 [plugin-path]/skills/consolidate-actions/consolidate-actions.py merge --ids=id1,id2 --name=patterns --dry-run
 ```
+
+`[plugin-path]` is the absolute path to this plugin root (the directory containing `commands/` and `skills/`).
 
 ## Actions
 

--- a/plugins/compound-learning/skills/consolidate-discovery/SKILL.md
+++ b/plugins/compound-learning/skills/consolidate-discovery/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: consolidate-discovery
-description: Find consolidation candidates in SQLite (compact output)
+description: Find duplicate and outdated learnings in SQLite. Use before proposing or running consolidation actions.
 ---
 
 # Consolidate Discovery
@@ -10,8 +10,10 @@ Discovers learnings that may need consolidation: duplicates and outdated content
 ## Usage
 
 ```bash
-python3 consolidate-discovery.py [--mode all|duplicates|outdated] [--limit N]
+python3 [plugin-path]/skills/consolidate-discovery/consolidate-discovery.py [--mode all|duplicates|outdated] [--limit N]
 ```
+
+`[plugin-path]` is the absolute path to this plugin root (the directory containing `commands/` and `skills/`).
 
 ## Options
 
@@ -50,4 +52,4 @@ Compact JSON with file basenames, paths, and IDs:
 
 - Uses tight similarity threshold (0.25) for true duplicates
 - Output is compact to avoid token bloat
-- Use consolidate-actions `get` to fetch full content when needed
+- Use `python3 [plugin-path]/skills/consolidate-actions/consolidate-actions.py get --ids=...` to fetch full content when needed

--- a/plugins/compound-learning/skills/index-learnings/SKILL.md
+++ b/plugins/compound-learning/skills/index-learnings/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: index-learnings
-description: Index learning files into SQLite and generate topic manifest
+description: Build or refresh the learnings SQLite index and topic manifest. Use when new or updated learnings need to be searchable.
 ---
 
 # Index Learnings
@@ -9,13 +9,24 @@ Indexes all learning markdown files into SQLite and generates a manifest summari
 
 ## Usage
 
+Preferred:
+
 ```
 /index-learnings
 ```
 
+Direct script (if command routing is unavailable):
+
+```bash
+python3 [plugin-path]/skills/index-learnings/index-learnings.py
+python3 [plugin-path]/skills/index-learnings/index-learnings.py --file /absolute/path/to/learning.md
+```
+
+`[plugin-path]` is the absolute path to this plugin root (the directory containing `commands/` and `skills/`).
+
 ## What It Does
 
-1. Discovers `.md` files in `~/.projects/learnings/` (global) and `[repo]/.projects/learnings/` (repo)
+1. Discovers `.md` files in `~/.projects/learnings/` (global) and `<repo-root>/.projects/learnings/` (repo)
 2. Extracts `**Topic:**` and `**Tags:**` from each file
 3. Indexes into SQLite
 4. Generates `~/.projects/learnings/MANIFEST.md`


### PR DESCRIPTION
## Summary
- Audited project skill scope using `README.md`, plugin README, command docs, and Agent Skills spec (`llms.txt` -> `specification.md`).
- Validated all plugin-local `SKILL.md` frontmatter/naming against spec constraints.
- Updated skill descriptions to better express trigger intent (`what` + `when`).
- Replaced ambiguous `python3 <script>.py` examples with anchored plugin-root paths.
- Synced `/consolidate-learnings` orchestration docs to the same invocation pattern.

## Files changed
- `plugins/compound-learning/skills/index-learnings/SKILL.md`
- `plugins/compound-learning/skills/consolidate-discovery/SKILL.md`
- `plugins/compound-learning/skills/consolidate-actions/SKILL.md`
- `plugins/compound-learning/commands/consolidate-learnings.md`

## Audit findings
- No `SKILL.md` files were found under repository-local `.claude/skills` or `.codex/skills`.
- Active project-local skills are currently under `plugins/compound-learning/skills`.
- Frontmatter for all 3 skills is valid (`name` format/length, `description` presence/length, `name == parent directory`).

## Validation evidence
- Frontmatter/naming validator: pass for all 3 skills.
- Script smoke checks:
  - `python3 plugins/compound-learning/skills/index-learnings/index-learnings.py --help`
  - `python3 plugins/compound-learning/skills/consolidate-discovery/consolidate-discovery.py --help`
  - `python3 plugins/compound-learning/skills/consolidate-actions/consolidate-actions.py merge --help`
- Stale-reference sweep for touched docs: pass (no bare `python3 consolidate-actions.py`/`consolidate-discovery.py` invocations remaining).
- Tests: `pytest -q` in `plugins/compound-learning` -> `25 passed, 8 skipped`.

## Follow-ups
- If desired, add repo-local `.claude/skills` or `.codex/skills` directories explicitly (currently absent).
- Consider adding a dedicated `search-learnings` SKILL wrapper for `scripts/search-learnings.py` to match README skill listings exactly.
