### PR TITLE
Instrument knowledge silo detector observability

### DIFF
--- a/plugins/compound-learning/README.md
+++ b/plugins/compound-learning/README.md
@@ -122,9 +122,11 @@ When observability is enabled, the plugin writes structured JSONL events for:
 - Search pipeline (keyword parse, repo scope, fan-out, merge/rerank/filter, threshold buckets, final status)
 - Index pipeline (discovery, per-file failures, prune summary, manifest generation, total runtime)
 - DB operations (connection open, schema init, embeddings, upsert/delete/vector search)
+- Knowledge silo detector (`detect-knowledge-silos.py`) lifecycle (validation, DB init/read, compute, truncation, output emit, terminal status)
 
 Event fields include: `timestamp`, `level`, `component`, `operation`, `status`, `duration_ms`, `counts`, optional `error`, and correlation/session identifiers when available.
-Hooks now export correlation/session context into Python subprocesses so hook events can be joined to search/index/db events in one trace.
+Hooks now export correlation/session context into Python subprocesses so hook events can be joined to search/index/db/detector events in one trace.
+Detector trace shape typically appears as: `config_load` -> `db_init` -> `db_read` -> `detector_compute` -> `truncation` -> `output_emit` -> `detector_complete`.
 
 ## Usage
 

--- a/plugins/compound-learning/scripts/detect-knowledge-silos.py
+++ b/plugins/compound-learning/scripts/detect-knowledge-silos.py
@@ -21,6 +21,7 @@ _PLUGIN_ROOT = os.environ.get(
 sys.path.insert(0, _PLUGIN_ROOT)
 
 import lib.db as db
+import lib.observability as observability
 
 
 ASSUMPTION_TEXT = (
@@ -530,56 +531,295 @@ def _validate_range(name: str, value: float) -> None:
         raise ValueError(f"{name} must be between 0 and 1, got {value}.")
 
 
+def _fallback_observability_config() -> Dict[str, Any]:
+    cfg: Dict[str, Any] = {
+        "enabled": os.environ.get("LEARNINGS_OBS_ENABLED", "false"),
+    }
+    level = os.environ.get("LEARNINGS_OBS_LEVEL")
+    if level:
+        cfg["level"] = level
+    log_path = os.environ.get("LEARNINGS_OBS_LOG_PATH")
+    if log_path:
+        cfg["logPath"] = os.path.expanduser(log_path)
+    return {"observability": cfg}
+
+
+def _detector_logger(config: Mapping[str, Any] | None = None) -> observability.StructuredLogger:
+    return observability.get_logger(
+        "knowledge_silo_detector",
+        config,
+        operation_name="detect_knowledge_silos",
+    )
+
+
+def _emit_terminal(
+    logger: observability.StructuredLogger,
+    started: float,
+    *,
+    status: str,
+    exit_code: int,
+    summary: Mapping[str, Any] | None = None,
+) -> None:
+    counts: Dict[str, Any] = {"exit_code": exit_code}
+    if isinstance(summary, Mapping):
+        for key in ("total_learnings", "topics_analyzed", "topics_with_findings"):
+            value = summary.get(key)
+            if isinstance(value, (int, float)):
+                counts[key] = int(value)
+
+    logger.emit(
+        "detector_complete",
+        status,
+        level="info" if status == "success" else "error",
+        duration_ms=observability.elapsed_ms(started),
+        counts=counts,
+    )
+
+
 def main() -> int:
     args = parse_args()
+    run_started = observability.now_perf()
+
+    fallback_config = _fallback_observability_config()
+    bootstrap_context = observability.attach_runtime_context(
+        fallback_config,
+        operation_name="detect_knowledge_silos",
+    )
+    logger = _detector_logger(fallback_config)
+
+    config_started = observability.now_perf()
+    try:
+        config = db.load_config()
+    except Exception as exc:
+        logger.emit(
+            "config_load",
+            "error",
+            level="error",
+            duration_ms=observability.elapsed_ms(config_started),
+            error=exc,
+        )
+        _emit_terminal(logger, run_started, status="error", exit_code=1)
+        print(f"Failed to initialize database connection: {exc}", file=sys.stderr)
+        return 1
+
+    observability.attach_runtime_context(
+        config,
+        operation_name="detect_knowledge_silos",
+        correlation_id=bootstrap_context.get("correlation_id"),
+        session_id=bootstrap_context.get("session_id"),
+    )
+    logger = _detector_logger(config)
+    logger.emit(
+        "config_load",
+        "success",
+        level="debug",
+        duration_ms=observability.elapsed_ms(config_started),
+    )
+    logger.emit(
+        "detector_run",
+        "start",
+        level="info",
+        counts={"max_findings": args.max_findings},
+        output_format=args.format,
+    )
 
     if args.min_topic_samples <= 0:
-        print("--min-topic-samples must be greater than 0.", file=sys.stderr)
+        message = "--min-topic-samples must be greater than 0."
+        logger.emit(
+            "validation",
+            "error",
+            level="error",
+            message=message,
+            counts={"min_topic_samples": args.min_topic_samples},
+        )
+        _emit_terminal(logger, run_started, status="error", exit_code=2)
+        print(message, file=sys.stderr)
         return 2
 
     if args.max_findings < 0:
-        print("--max-findings cannot be negative.", file=sys.stderr)
+        message = "--max-findings cannot be negative."
+        logger.emit(
+            "validation",
+            "error",
+            level="error",
+            message=message,
+            counts={"max_findings": args.max_findings},
+        )
+        _emit_terminal(logger, run_started, status="error", exit_code=2)
+        print(message, file=sys.stderr)
         return 2
 
     try:
         _validate_range("--repo-dominance-threshold", args.repo_dominance_threshold)
         _validate_range("--author-dominance-threshold", args.author_dominance_threshold)
     except ValueError as exc:
-        print(str(exc), file=sys.stderr)
+        message = str(exc)
+        logger.emit(
+            "validation",
+            "error",
+            level="error",
+            message=message,
+            counts={
+                "repo_dominance_threshold": args.repo_dominance_threshold,
+                "author_dominance_threshold": args.author_dominance_threshold,
+            },
+        )
+        _emit_terminal(logger, run_started, status="error", exit_code=2)
+        print(message, file=sys.stderr)
         return 2
 
+    db_init_started = observability.now_perf()
+    logger.emit("db_init", "start", level="debug")
     try:
-        config = db.load_config()
         conn = db.get_connection(config)
     except Exception as exc:
+        logger.emit(
+            "db_init",
+            "error",
+            level="error",
+            duration_ms=observability.elapsed_ms(db_init_started),
+            error=exc,
+        )
+        _emit_terminal(logger, run_started, status="error", exit_code=1)
         print(f"Failed to initialize database connection: {exc}", file=sys.stderr)
         return 1
+    logger.emit(
+        "db_init",
+        "success",
+        level="info",
+        duration_ms=observability.elapsed_ms(db_init_started),
+        counts={"connections": 1},
+    )
 
+    read_started = observability.now_perf()
+    logger.emit("db_read", "start", level="debug")
     try:
         rows = fetch_indexed_learnings(conn)
     except Exception as exc:
+        logger.emit(
+            "db_read",
+            "error",
+            level="error",
+            duration_ms=observability.elapsed_ms(read_started),
+            error=exc,
+        )
         print(f"Failed to read indexed learnings: {exc}", file=sys.stderr)
-        conn.close()
+        _emit_terminal(logger, run_started, status="error", exit_code=1)
         return 1
-
-    conn.close()
-
-    report = detect_knowledge_silos(
-        rows,
-        min_topic_samples=args.min_topic_samples,
-        repo_dominance_threshold=args.repo_dominance_threshold,
-        author_dominance_threshold=args.author_dominance_threshold,
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            # Closing a failed connection should not change detector behavior.
+            pass
+    logger.emit(
+        "db_read",
+        "success",
+        level="info",
+        duration_ms=observability.elapsed_ms(read_started),
+        counts={"rows_read": len(rows)},
     )
 
-    if args.max_findings and len(report["findings"]) > args.max_findings:
+    compute_started = observability.now_perf()
+    logger.emit(
+        "detector_compute",
+        "start",
+        level="info",
+        counts={"rows_read": len(rows)},
+    )
+    try:
+        report = detect_knowledge_silos(
+            rows,
+            min_topic_samples=args.min_topic_samples,
+            repo_dominance_threshold=args.repo_dominance_threshold,
+            author_dominance_threshold=args.author_dominance_threshold,
+        )
+    except Exception as exc:
+        logger.emit(
+            "detector_compute",
+            "error",
+            level="error",
+            duration_ms=observability.elapsed_ms(compute_started),
+            error=exc,
+            counts={"rows_read": len(rows)},
+        )
+        _emit_terminal(logger, run_started, status="error", exit_code=1)
+        raise
+    summary = report.get("summary", {})
+    logger.emit(
+        "detector_compute",
+        "success",
+        level="info",
+        duration_ms=observability.elapsed_ms(compute_started),
+        counts={
+            "rows_read": len(rows),
+            "topics_analyzed": summary.get("topics_analyzed", 0),
+            "topics_with_findings": summary.get("topics_with_findings", 0),
+        },
+    )
+
+    findings_before = len(report["findings"])
+    if args.max_findings and findings_before > args.max_findings:
         report["findings"] = report["findings"][: args.max_findings]
         report["summary"]["topics_with_findings"] = len(report["findings"])
         report["truncated"] = True
-
-    if args.format == "json":
-        print(json.dumps(report, indent=2, sort_keys=True))
+        logger.emit(
+            "truncation",
+            "applied",
+            level="info",
+            counts={
+                "findings_before": findings_before,
+                "findings_after": len(report["findings"]),
+                "max_findings": args.max_findings,
+            },
+        )
+    elif args.max_findings == 0:
+        logger.emit(
+            "truncation",
+            "disabled",
+            level="debug",
+            counts={
+                "findings_before": findings_before,
+                "max_findings": args.max_findings,
+            },
+        )
     else:
-        print(render_text_report(report))
+        logger.emit(
+            "truncation",
+            "not_needed",
+            level="debug",
+            counts={
+                "findings_before": findings_before,
+                "max_findings": args.max_findings,
+            },
+        )
+
+    emit_started = observability.now_perf()
+    try:
+        if args.format == "json":
+            print(json.dumps(report, indent=2, sort_keys=True))
+        else:
+            print(render_text_report(report))
+    except Exception as exc:
+        logger.emit(
+            "output_emit",
+            "error",
+            level="error",
+            duration_ms=observability.elapsed_ms(emit_started),
+            error=exc,
+            output_format=args.format,
+        )
+        _emit_terminal(logger, run_started, status="error", exit_code=1, summary=summary)
+        raise
+    logger.emit(
+        "output_emit",
+        "success",
+        level="info",
+        duration_ms=observability.elapsed_ms(emit_started),
+        counts={"findings_emitted": len(report.get("findings", []))},
+        output_format=args.format,
+    )
+    _emit_terminal(logger, run_started, status="success", exit_code=0, summary=summary)
 
     return 0
 

--- a/plugins/compound-learning/tests/test_knowledge_silo_detector.py
+++ b/plugins/compound-learning/tests/test_knowledge_silo_detector.py
@@ -1,4 +1,6 @@
+import argparse
 import importlib.util
+import json
 import sys
 from pathlib import Path
 
@@ -41,6 +43,55 @@ def test_empty_dataset_returns_guidance():
     assert report["findings"] == []
     assert "index-learnings" in report["guidance"]
     assert report["summary"]["total_learnings"] == 0
+
+
+def test_main_validation_failure_emits_observability(monkeypatch, capsys, tmp_path):
+    log_path = tmp_path / "detector-observability.jsonl"
+    config = {
+        "observability": {
+            "enabled": True,
+            "level": "debug",
+            "logPath": str(log_path),
+        }
+    }
+    args = argparse.Namespace(
+        min_topic_samples=0,
+        repo_dominance_threshold=0.70,
+        author_dominance_threshold=0.65,
+        max_findings=25,
+        format="text",
+    )
+
+    def fail_if_called(_config):
+        raise AssertionError("db.get_connection should not be called on validation failure")
+
+    monkeypatch.setattr(DETECTOR, "parse_args", lambda: args)
+    monkeypatch.setattr(DETECTOR.db, "load_config", lambda: config)
+    monkeypatch.setattr(DETECTOR.db, "get_connection", fail_if_called)
+
+    exit_code = DETECTOR.main()
+    captured = capsys.readouterr()
+
+    assert exit_code == 2
+    assert captured.out == ""
+    assert captured.err.strip() == "--min-topic-samples must be greater than 0."
+    assert log_path.exists()
+
+    events = [
+        json.loads(line)
+        for line in log_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert any(
+        event.get("operation") == "validation" and event.get("status") == "error"
+        for event in events
+    )
+    assert any(
+        event.get("operation") == "detector_complete"
+        and event.get("status") == "error"
+        and event.get("counts", {}).get("exit_code") == 2
+        for event in events
+    )
 
 
 def test_single_repo_dominance_detected():

--- a/plugins/compound-learning/tests/test_observability.py
+++ b/plugins/compound-learning/tests/test_observability.py
@@ -1,3 +1,4 @@
+import argparse
 import importlib.util
 import json
 import sys
@@ -14,6 +15,13 @@ _search_spec = importlib.util.spec_from_file_location(
 )
 search_module = importlib.util.module_from_spec(_search_spec)
 _search_spec.loader.exec_module(search_module)
+
+_detector_spec = importlib.util.spec_from_file_location(
+    "knowledge_silo_detector",
+    PLUGIN_ROOT / "scripts" / "detect-knowledge-silos.py",
+)
+detector_module = importlib.util.module_from_spec(_detector_spec)
+_detector_spec.loader.exec_module(detector_module)
 
 
 def test_structured_event_shape(tmp_path):
@@ -154,3 +162,55 @@ def test_search_stdout_contract_with_observability(monkeypatch, capsys, tmp_path
     assert lines
     assert all(event.get("correlation_id") == "corr-hook-abc" for event in lines)
     assert all(event.get("session_id") == "sess-hook-abc" for event in lines)
+
+
+def test_detector_stdout_contract_with_observability(monkeypatch, capsys, tmp_path):
+    log_path = tmp_path / "detector-observability.jsonl"
+    config = {
+        "observability": {
+            "enabled": True,
+            "level": "debug",
+            "logPath": str(log_path),
+        }
+    }
+    args = argparse.Namespace(
+        min_topic_samples=4,
+        repo_dominance_threshold=0.70,
+        author_dominance_threshold=0.65,
+        max_findings=2,
+        format="json",
+    )
+    monkeypatch.setenv("LEARNINGS_OBS_CORRELATION_ID", "corr-detector-xyz")
+    monkeypatch.setenv("LEARNINGS_OBS_SESSION_ID", "sess-detector-xyz")
+
+    class FakeConn:
+        def close(self):
+            return None
+
+    monkeypatch.setattr(detector_module, "parse_args", lambda: args)
+    monkeypatch.setattr(detector_module.db, "load_config", lambda: config)
+    monkeypatch.setattr(detector_module.db, "get_connection", lambda _config: FakeConn())
+    monkeypatch.setattr(detector_module, "fetch_indexed_learnings", lambda _conn: [])
+
+    exit_code = detector_module.main()
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert captured.err == ""
+    payload = json.loads(captured.out)
+    assert payload["status"] == "empty"
+    assert payload["summary"]["total_learnings"] == 0
+
+    lines = [
+        json.loads(line)
+        for line in log_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert lines
+    assert all(event.get("correlation_id") == "corr-detector-xyz" for event in lines)
+    assert all(event.get("session_id") == "sess-detector-xyz" for event in lines)
+
+    operations = {event.get("operation") for event in lines}
+    assert {"db_init", "db_read", "detector_compute", "output_emit", "detector_complete"}.issubset(
+        operations
+    )


### PR DESCRIPTION
## Summary
- instrumented `scripts/detect-knowledge-silos.py` with structured observability lifecycle events while preserving stdout/stderr and exit-code behavior
- added runtime context propagation, validation/error event emission, DB init/read events, compute/truncation/output/terminal events
- extended detector and observability tests for detector observability emission, correlation/session propagation, and machine-parseable JSON output contract
- documented knowledge-silo-detector coverage in README observability section

## Scope / Assumption
- This change intentionally instruments only the knowledge silo detector execution path as the minimal high-value observability increment; existing hooks/search/index/db observability remains unchanged.

## Test Evidence
- `pytest -q plugins/compound-learning/tests/test_knowledge_silo_detector.py plugins/compound-learning/tests/test_observability.py`
- `pytest -q plugins/compound-learning/tests`

## Notes
- User-facing detector stdout/stderr behavior and return codes are preserved; observability output is file-only JSONL.