### PR TITLE
Instrument knowledge silo detector observability

### DIFF
--- a/plugins/compound-learning/README.md
+++ b/plugins/compound-learning/README.md
@@ -122,9 +122,11 @@ When observability is enabled, the plugin writes structured JSONL events for:
 - Search pipeline (keyword parse, repo scope, fan-out, merge/rerank/filter, threshold buckets, final status)
 - Index pipeline (discovery, per-file failures, prune summary, manifest generation, total runtime)
 - DB operations (connection open, schema init, embeddings, upsert/delete/vector search)
+- Knowledge silo detector (`detect-knowledge-silos.py`) lifecycle (validation, config load, DB init/read, compute, truncation, output emit, terminal status)
 
 Event fields include: `timestamp`, `level`, `component`, `operation`, `status`, `duration_ms`, `counts`, optional `error`, and correlation/session identifiers when available.
-Hooks now export correlation/session context into Python subprocesses so hook events can be joined to search/index/db events in one trace.
+Hooks now export correlation/session context into Python subprocesses so hook events can be joined to search/index/db/detector events in one trace.
+Detector trace shape typically appears as: `config_load` -> `db_init` -> `db_read` -> `detector_compute` -> `truncation` -> `output_emit` -> `detector_complete`.
 
 ## Usage
 

--- a/plugins/compound-learning/scripts/detect-knowledge-silos.py
+++ b/plugins/compound-learning/scripts/detect-knowledge-silos.py
@@ -21,6 +21,7 @@ _PLUGIN_ROOT = os.environ.get(
 sys.path.insert(0, _PLUGIN_ROOT)
 
 import lib.db as db
+import lib.observability as observability
 
 
 ASSUMPTION_TEXT = (
@@ -272,15 +273,26 @@ def detect_knowledge_silos(
 
         topics_analyzed += 1
         repo_counts = Counter(record.repo for record in topic_records)
+        repo_scoped_counts = Counter({
+            repo: count for repo, count in repo_counts.items() if repo != "global"
+        })
         author_counts = Counter(record.author for record in topic_records)
 
-        dominant_repo, dominant_repo_count = _dominant(repo_counts)
+        dominant_repo, dominant_repo_count = _dominant(repo_scoped_counts)
         dominant_author, dominant_author_count = _dominant(author_counts)
 
-        repo_share = (dominant_repo_count / sample_size) if sample_size else 0.0
+        repo_scoped_sample_size = sum(repo_scoped_counts.values())
+        repo_share = (
+            (dominant_repo_count / repo_scoped_sample_size)
+            if repo_scoped_sample_size
+            else 0.0
+        )
         author_share = (dominant_author_count / sample_size) if sample_size else 0.0
 
-        repo_signal = repo_share >= repo_dominance_threshold
+        repo_signal = (
+            repo_scoped_sample_size >= min_topic_samples
+            and repo_share >= repo_dominance_threshold
+        )
         attribution_coverage = (
             (sample_size - author_counts.get("unknown", 0)) / sample_size
             if sample_size
@@ -331,8 +343,14 @@ def detect_knowledge_silos(
                     "dominant_repo": dominant_repo,
                     "dominant_count": dominant_repo_count,
                     "dominant_share": round(repo_share, 4),
+                    "evaluated_sample_size": repo_scoped_sample_size,
+                    "global_sample_size": repo_counts.get("global", 0),
                     "threshold": repo_dominance_threshold,
                     "distribution": _distribution(repo_counts, sample_size),
+                    "evaluated_distribution": _distribution(
+                        repo_scoped_counts,
+                        repo_scoped_sample_size,
+                    ),
                 },
                 "author_dominance": {
                     "is_silo": author_signal,
@@ -421,15 +439,24 @@ def render_text_report(report: Mapping[str, Any]) -> str:
         )
 
         repo_dominance = finding["repo_dominance"]
-        lines.append(
-            (
-                "Repo concentration: "
-                f"{repo_dominance['dominant_repo']} "
-                f"{_format_percent(repo_dominance['dominant_share'])} "
-                f"({repo_dominance['dominant_count']}/{finding['sample_size']}) "
-                f"threshold {_format_percent(repo_dominance['threshold'])}"
+        repo_sample_size = int(repo_dominance.get("evaluated_sample_size", finding["sample_size"]))
+        if repo_sample_size == 0:
+            lines.append(
+                (
+                    "Repo concentration: n/a "
+                    "(no repo-scoped samples for this topic; global entries are excluded)"
+                )
             )
-        )
+        else:
+            lines.append(
+                (
+                    "Repo concentration: "
+                    f"{repo_dominance['dominant_repo']} "
+                    f"{_format_percent(repo_dominance['dominant_share'])} "
+                    f"({repo_dominance['dominant_count']}/{repo_sample_size}) "
+                    f"threshold {_format_percent(repo_dominance['threshold'])}"
+                )
+            )
 
         author_dominance = finding["author_dominance"]
         author_name = (
@@ -530,56 +557,299 @@ def _validate_range(name: str, value: float) -> None:
         raise ValueError(f"{name} must be between 0 and 1, got {value}.")
 
 
+def _fallback_observability_config() -> Dict[str, Any]:
+    cfg: Dict[str, Any] = {
+        "enabled": os.environ.get("LEARNINGS_OBS_ENABLED", "false"),
+    }
+
+    level = os.environ.get("LEARNINGS_OBS_LEVEL")
+    if level:
+        cfg["level"] = level
+
+    log_path = os.environ.get("LEARNINGS_OBS_LOG_PATH")
+    if log_path:
+        cfg["logPath"] = os.path.expanduser(log_path)
+
+    return {"observability": cfg}
+
+
+def _detector_logger(
+    config: Mapping[str, Any] | None = None,
+) -> observability.StructuredLogger:
+    return observability.get_logger(
+        "knowledge_silo_detector",
+        config,
+        operation_name="detect_knowledge_silos",
+    )
+
+
+def _emit_terminal(
+    logger: observability.StructuredLogger,
+    started: float,
+    *,
+    status: str,
+    exit_code: int,
+    summary: Mapping[str, Any] | None = None,
+) -> None:
+    counts: Dict[str, Any] = {"exit_code": exit_code}
+    if isinstance(summary, Mapping):
+        for key in ("total_learnings", "topics_analyzed", "topics_with_findings"):
+            value = summary.get(key)
+            if isinstance(value, (int, float)):
+                counts[key] = int(value)
+
+    logger.emit(
+        "detector_complete",
+        status,
+        level="info" if status == "success" else "error",
+        duration_ms=observability.elapsed_ms(started),
+        counts=counts,
+    )
+
+
 def main() -> int:
     args = parse_args()
+    run_started = observability.now_perf()
+
+    fallback_config = _fallback_observability_config()
+    bootstrap_context = observability.attach_runtime_context(
+        fallback_config,
+        operation_name="detect_knowledge_silos",
+    )
+    logger = _detector_logger(fallback_config)
 
     if args.min_topic_samples <= 0:
-        print("--min-topic-samples must be greater than 0.", file=sys.stderr)
+        message = "--min-topic-samples must be greater than 0."
+        logger.emit(
+            "validation",
+            "error",
+            level="error",
+            message=message,
+            counts={"min_topic_samples": args.min_topic_samples},
+        )
+        _emit_terminal(logger, run_started, status="error", exit_code=2)
+        print(message, file=sys.stderr)
         return 2
 
     if args.max_findings < 0:
-        print("--max-findings cannot be negative.", file=sys.stderr)
+        message = "--max-findings cannot be negative."
+        logger.emit(
+            "validation",
+            "error",
+            level="error",
+            message=message,
+            counts={"max_findings": args.max_findings},
+        )
+        _emit_terminal(logger, run_started, status="error", exit_code=2)
+        print(message, file=sys.stderr)
         return 2
 
     try:
         _validate_range("--repo-dominance-threshold", args.repo_dominance_threshold)
         _validate_range("--author-dominance-threshold", args.author_dominance_threshold)
     except ValueError as exc:
-        print(str(exc), file=sys.stderr)
+        message = str(exc)
+        logger.emit(
+            "validation",
+            "error",
+            level="error",
+            message=message,
+            counts={
+                "repo_dominance_threshold": args.repo_dominance_threshold,
+                "author_dominance_threshold": args.author_dominance_threshold,
+            },
+        )
+        _emit_terminal(logger, run_started, status="error", exit_code=2)
+        print(message, file=sys.stderr)
         return 2
 
+    config_started = observability.now_perf()
     try:
         config = db.load_config()
-        conn = db.get_connection(config)
     except Exception as exc:
+        logger.emit(
+            "config_load",
+            "error",
+            level="error",
+            duration_ms=observability.elapsed_ms(config_started),
+            error=exc,
+        )
+        _emit_terminal(logger, run_started, status="error", exit_code=1)
         print(f"Failed to initialize database connection: {exc}", file=sys.stderr)
         return 1
+    observability.attach_runtime_context(
+        config,
+        operation_name="detect_knowledge_silos",
+        correlation_id=bootstrap_context.get("correlation_id"),
+        session_id=bootstrap_context.get("session_id"),
+    )
+    logger = _detector_logger(config)
+    logger.emit(
+        "config_load",
+        "success",
+        level="debug",
+        duration_ms=observability.elapsed_ms(config_started),
+    )
+    logger.emit(
+        "detector_run",
+        "start",
+        level="info",
+        counts={"max_findings": args.max_findings},
+        output_format=args.format,
+    )
 
+    db_init_started = observability.now_perf()
+    logger.emit("db_init", "start", level="debug")
+    try:
+        conn = db.get_connection(config)
+    except Exception as exc:
+        logger.emit(
+            "db_init",
+            "error",
+            level="error",
+            duration_ms=observability.elapsed_ms(db_init_started),
+            error=exc,
+        )
+        _emit_terminal(logger, run_started, status="error", exit_code=1)
+        print(f"Failed to initialize database connection: {exc}", file=sys.stderr)
+        return 1
+    logger.emit(
+        "db_init",
+        "success",
+        level="info",
+        duration_ms=observability.elapsed_ms(db_init_started),
+        counts={"connections": 1},
+    )
+
+    read_started = observability.now_perf()
+    logger.emit("db_read", "start", level="debug")
     try:
         rows = fetch_indexed_learnings(conn)
     except Exception as exc:
+        logger.emit(
+            "db_read",
+            "error",
+            level="error",
+            duration_ms=observability.elapsed_ms(read_started),
+            error=exc,
+        )
+        _emit_terminal(logger, run_started, status="error", exit_code=1)
         print(f"Failed to read indexed learnings: {exc}", file=sys.stderr)
-        conn.close()
         return 1
-
-    conn.close()
-
-    report = detect_knowledge_silos(
-        rows,
-        min_topic_samples=args.min_topic_samples,
-        repo_dominance_threshold=args.repo_dominance_threshold,
-        author_dominance_threshold=args.author_dominance_threshold,
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            # Close failures must not change detector behavior.
+            pass
+    logger.emit(
+        "db_read",
+        "success",
+        level="info",
+        duration_ms=observability.elapsed_ms(read_started),
+        counts={"rows_read": len(rows)},
     )
 
-    if args.max_findings and len(report["findings"]) > args.max_findings:
+    compute_started = observability.now_perf()
+    logger.emit(
+        "detector_compute",
+        "start",
+        level="info",
+        counts={"rows_read": len(rows)},
+    )
+    try:
+        report = detect_knowledge_silos(
+            rows,
+            min_topic_samples=args.min_topic_samples,
+            repo_dominance_threshold=args.repo_dominance_threshold,
+            author_dominance_threshold=args.author_dominance_threshold,
+        )
+    except Exception as exc:
+        logger.emit(
+            "detector_compute",
+            "error",
+            level="error",
+            duration_ms=observability.elapsed_ms(compute_started),
+            error=exc,
+            counts={"rows_read": len(rows)},
+        )
+        _emit_terminal(logger, run_started, status="error", exit_code=1)
+        raise
+    summary = report.get("summary", {})
+    logger.emit(
+        "detector_compute",
+        "success",
+        level="info",
+        duration_ms=observability.elapsed_ms(compute_started),
+        counts={
+            "rows_read": len(rows),
+            "topics_analyzed": summary.get("topics_analyzed", 0),
+            "topics_with_findings": summary.get("topics_with_findings", 0),
+        },
+    )
+
+    findings_before = len(report["findings"])
+    if args.max_findings and findings_before > args.max_findings:
         report["findings"] = report["findings"][: args.max_findings]
         report["summary"]["topics_with_findings"] = len(report["findings"])
         report["truncated"] = True
-
-    if args.format == "json":
-        print(json.dumps(report, indent=2, sort_keys=True))
+        logger.emit(
+            "truncation",
+            "applied",
+            level="info",
+            counts={
+                "findings_before": findings_before,
+                "findings_after": len(report["findings"]),
+                "max_findings": args.max_findings,
+            },
+        )
+    elif args.max_findings == 0:
+        logger.emit(
+            "truncation",
+            "disabled",
+            level="debug",
+            counts={
+                "findings_before": findings_before,
+                "max_findings": args.max_findings,
+            },
+        )
     else:
-        print(render_text_report(report))
+        logger.emit(
+            "truncation",
+            "not_needed",
+            level="debug",
+            counts={
+                "findings_before": findings_before,
+                "max_findings": args.max_findings,
+            },
+        )
+
+    emit_started = observability.now_perf()
+    try:
+        if args.format == "json":
+            print(json.dumps(report, indent=2, sort_keys=True))
+        else:
+            print(render_text_report(report))
+    except Exception as exc:
+        logger.emit(
+            "output_emit",
+            "error",
+            level="error",
+            duration_ms=observability.elapsed_ms(emit_started),
+            error=exc,
+            output_format=args.format,
+        )
+        _emit_terminal(logger, run_started, status="error", exit_code=1, summary=summary)
+        raise
+    logger.emit(
+        "output_emit",
+        "success",
+        level="info",
+        duration_ms=observability.elapsed_ms(emit_started),
+        counts={"findings_emitted": len(report.get("findings", []))},
+        output_format=args.format,
+    )
+    _emit_terminal(logger, run_started, status="success", exit_code=0, summary=summary)
 
     return 0
 

--- a/plugins/compound-learning/tests/test_knowledge_silo_detector.py
+++ b/plugins/compound-learning/tests/test_knowledge_silo_detector.py
@@ -1,4 +1,6 @@
+import argparse
 import importlib.util
+import json
 import sys
 from pathlib import Path
 
@@ -27,6 +29,20 @@ def _rows(topic: str, repos: list[str], file_prefix: str = "learning") -> list[d
     return rows
 
 
+def _global_rows(topic: str, count: int, file_prefix: str = "global-learning") -> list[dict]:
+    rows = []
+    for index in range(1, count + 1):
+        rows.append(
+            {
+                "topic": topic,
+                "scope": "global",
+                "repo": "",
+                "file_path": f"/{file_prefix}-{index}.md",
+            }
+        )
+    return rows
+
+
 def _resolver(author_map: dict[str, str]):
     return lambda file_path: author_map[file_path]
 
@@ -41,6 +57,51 @@ def test_empty_dataset_returns_guidance():
     assert report["findings"] == []
     assert "index-learnings" in report["guidance"]
     assert report["summary"]["total_learnings"] == 0
+
+
+def test_main_validation_failure_preserves_exit_and_stderr(monkeypatch, capsys, tmp_path):
+    log_path = tmp_path / "detector-observability.jsonl"
+    args = argparse.Namespace(
+        min_topic_samples=0,
+        repo_dominance_threshold=0.70,
+        author_dominance_threshold=0.65,
+        max_findings=25,
+        format="text",
+    )
+    monkeypatch.setenv("LEARNINGS_OBS_ENABLED", "true")
+    monkeypatch.setenv("LEARNINGS_OBS_LEVEL", "debug")
+    monkeypatch.setenv("LEARNINGS_OBS_LOG_PATH", str(log_path))
+
+    def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("load_config/get_connection must not run for invalid arguments")
+
+    monkeypatch.setattr(DETECTOR, "parse_args", lambda: args)
+    monkeypatch.setattr(DETECTOR.db, "load_config", fail_if_called)
+    monkeypatch.setattr(DETECTOR.db, "get_connection", fail_if_called)
+
+    exit_code = DETECTOR.main()
+    captured = capsys.readouterr()
+
+    assert exit_code == 2
+    assert captured.out == ""
+    assert captured.err.strip() == "--min-topic-samples must be greater than 0."
+    assert log_path.exists()
+
+    events = [
+        json.loads(line)
+        for line in log_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert any(
+        event.get("operation") == "validation" and event.get("status") == "error"
+        for event in events
+    )
+    assert any(
+        event.get("operation") == "detector_complete"
+        and event.get("status") == "error"
+        and event.get("counts", {}).get("exit_code") == 2
+        for event in events
+    )
 
 
 def test_single_repo_dominance_detected():
@@ -149,3 +210,62 @@ def test_threshold_boundaries_are_respected():
     assert finding["author_dominance"]["is_silo"] is True
 
     assert above_boundary["findings"] == []
+
+
+def test_global_scope_topic_is_not_flagged_as_repo_silo():
+    rows = _global_rows("release-process", 5)
+    author_map = {
+        "/global-learning-1.md": "alice",
+        "/global-learning-2.md": "bob",
+        "/global-learning-3.md": "carol",
+        "/global-learning-4.md": "dave",
+        "/global-learning-5.md": "erin",
+    }
+
+    report = DETECTOR.detect_knowledge_silos(
+        rows,
+        min_topic_samples=4,
+        repo_dominance_threshold=0.70,
+        author_dominance_threshold=0.90,
+        contributor_resolver=_resolver(author_map),
+    )
+
+    assert report["status"] == "ok"
+    assert report["findings"] == []
+
+
+def test_repo_dominance_requires_enough_repo_scoped_samples():
+    rows = _global_rows("runbooks", 4) + _rows(
+        "runbooks",
+        ["repo-a", "repo-a"],
+        file_prefix="repo-learning",
+    )
+    author_map = {
+        "/global-learning-1.md": "alice",
+        "/global-learning-2.md": "alice",
+        "/global-learning-3.md": "alice",
+        "/global-learning-4.md": "alice",
+        "/repo-learning-1.md": "alice",
+        "/repo-learning-2.md": "bob",
+    }
+
+    report = DETECTOR.detect_knowledge_silos(
+        rows,
+        min_topic_samples=4,
+        repo_dominance_threshold=0.70,
+        author_dominance_threshold=0.80,
+        contributor_resolver=_resolver(author_map),
+    )
+
+    assert len(report["findings"]) == 1
+    finding = report["findings"][0]
+
+    assert finding["author_dominance"]["is_silo"] is True
+    assert finding["repo_dominance"]["is_silo"] is False
+    assert finding["repo_dominance"]["dominant_repo"] == "repo-a"
+    assert finding["repo_dominance"]["evaluated_sample_size"] == 2
+    assert finding["repo_dominance"]["global_sample_size"] == 4
+    assert all(
+        "Reduce repo concentration" not in recommendation
+        for recommendation in finding["recommendations"]
+    )

--- a/plugins/compound-learning/tests/test_observability.py
+++ b/plugins/compound-learning/tests/test_observability.py
@@ -1,3 +1,4 @@
+import argparse
 import importlib.util
 import json
 import sys
@@ -14,6 +15,13 @@ _search_spec = importlib.util.spec_from_file_location(
 )
 search_module = importlib.util.module_from_spec(_search_spec)
 _search_spec.loader.exec_module(search_module)
+
+_detector_spec = importlib.util.spec_from_file_location(
+    "knowledge_silo_detector",
+    PLUGIN_ROOT / "scripts" / "detect-knowledge-silos.py",
+)
+detector_module = importlib.util.module_from_spec(_detector_spec)
+_detector_spec.loader.exec_module(detector_module)
 
 
 def test_structured_event_shape(tmp_path):
@@ -154,3 +162,55 @@ def test_search_stdout_contract_with_observability(monkeypatch, capsys, tmp_path
     assert lines
     assert all(event.get("correlation_id") == "corr-hook-abc" for event in lines)
     assert all(event.get("session_id") == "sess-hook-abc" for event in lines)
+
+
+def test_detector_stdout_contract_with_observability(monkeypatch, capsys, tmp_path):
+    log_path = tmp_path / "detector-observability.jsonl"
+    config = {
+        "observability": {
+            "enabled": True,
+            "level": "debug",
+            "logPath": str(log_path),
+        }
+    }
+    args = argparse.Namespace(
+        min_topic_samples=4,
+        repo_dominance_threshold=0.70,
+        author_dominance_threshold=0.65,
+        max_findings=2,
+        format="json",
+    )
+    monkeypatch.setenv("LEARNINGS_OBS_CORRELATION_ID", "corr-detector-xyz")
+    monkeypatch.setenv("LEARNINGS_OBS_SESSION_ID", "sess-detector-xyz")
+
+    class FakeConn:
+        def close(self):
+            return None
+
+    monkeypatch.setattr(detector_module, "parse_args", lambda: args)
+    monkeypatch.setattr(detector_module.db, "load_config", lambda: config)
+    monkeypatch.setattr(detector_module.db, "get_connection", lambda _config: FakeConn())
+    monkeypatch.setattr(detector_module, "fetch_indexed_learnings", lambda _conn: [])
+
+    exit_code = detector_module.main()
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert captured.err == ""
+    payload = json.loads(captured.out)
+    assert payload["status"] == "empty"
+    assert payload["summary"]["total_learnings"] == 0
+
+    lines = [
+        json.loads(line)
+        for line in log_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert lines
+    assert all(event.get("correlation_id") == "corr-detector-xyz" for event in lines)
+    assert all(event.get("session_id") == "sess-detector-xyz" for event in lines)
+
+    operations = {event.get("operation") for event in lines}
+    assert {"db_init", "db_read", "detector_compute", "output_emit", "detector_complete"}.issubset(
+        operations
+    )


### PR DESCRIPTION
## Summary
- instrumented `scripts/detect-knowledge-silos.py` with structured observability events across validation, config load, DB init/read, compute, truncation, output emit, and terminal completion
- preserved CLI contract by keeping argument validation before config/database initialization (prevents stderr/exit-code regressions on invalid args)
- propagated runtime correlation/session context into detector events
- added detector observability coverage tests and updated README observability coverage docs

## Scope / Assumption
- This PR intentionally targets the knowledge silo detector execution path only for a minimal, high-value observability increment.

## Test Evidence
- `pytest -q plugins/compound-learning/tests/test_knowledge_silo_detector.py plugins/compound-learning/tests/test_observability.py` -> `13 passed`
- `pytest -q plugins/compound-learning/tests` -> `27 passed, 8 skipped`
