### PR TITLE
Add semantic diff explainer command to compound-learning

### DIFF
--- a/plugins/compound-learning/.claude-plugin/plugin.json
+++ b/plugins/compound-learning/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "compound-learning",
-  "version": "0.3.1",
+  "version": "0.3.3",
   "description": "Learning compounding system with local vector search",
   "keywords": ["learning", "knowledge-base", "ai-memory"]
 }

--- a/plugins/compound-learning/README.md
+++ b/plugins/compound-learning/README.md
@@ -197,6 +197,27 @@ Typical workflow:
 3. Address recommendations (cross-repo propagation, contributor backup coverage)
 4. Re-run `/index-learnings` and detector to verify risk reduction
 
+### Explaining Semantic Diffs
+
+```
+/semantic-diff
+```
+
+Explain semantic meaning for local workspace changes (`HEAD` vs current index + working tree).
+
+Additional modes:
+
+```bash
+/semantic-diff --staged
+/semantic-diff --working-tree
+/semantic-diff main..HEAD
+/semantic-diff main...feature-branch
+```
+
+The command uses `scripts/semantic-diff.py` to gather deterministic structured diff context
+(status, rename metadata, numstat, bounded patch snippets), then calls `semantic-diff-explainer`
+to summarize behavioral impact, contract changes, risk level, and recommended test focus.
+
 ### Learnings Manifest
 
 The manifest helps Claude decide when to search by showing what topics have learnings:
@@ -248,10 +269,12 @@ How it works:
   - `/index-learnings`: Re-indexes all learning files into SQLite-vec
   - `/knowledge-silo-detector`: Detects topic concentration risk across repos and contributors
   - `/consolidate-learnings`: Finds and merges duplicate or overlapping learnings
+  - `/semantic-diff`: Explains semantic meaning of local git diff ranges and workspace changes
 
 - **Agents:**
   - `learning-writer`: Analyzes conversations and extracts learnings
   - `pr-learning-extractor`: Analyzes GitHub PRs and extracts learnings from reviews
+  - `semantic-diff-explainer`: Interprets structured diff payloads into behavior/risk analysis
 
 - **Skills:**
   - `search-learnings`: Queries SQLite-vec for relevant learnings with hierarchical scoping

--- a/plugins/compound-learning/agents/semantic-diff-explainer.md
+++ b/plugins/compound-learning/agents/semantic-diff-explainer.md
@@ -1,0 +1,53 @@
+---
+name: semantic-diff-explainer
+description: Explains the semantic meaning and risk profile of git code changes
+model: sonnet
+---
+
+You are a Semantic Diff Explainer. You convert structured git diff data into a concise explanation of what changed and why it matters.
+
+## Input
+
+You will receive a JSON payload produced by `scripts/semantic-diff.py` with:
+- `summary` counts and status distribution
+- `files[]` entries containing status, paths, stats, and bounded patch snippets
+- `notes` and optional `untracked_files`
+
+## Your Analysis Rules
+
+1. Use the diff payload as source-of-truth. Do not invent files or behavior.
+2. Prioritize behavior over syntax:
+- Explain runtime behavior, data flow, and side effects.
+- Distinguish internal refactors from externally visible changes.
+3. Always assess contract surfaces:
+- API request/response shapes
+- DB/schema/migration impact
+- Config/env expectations
+- File format or protocol compatibility
+4. Assign risk level (`low`, `medium`, `high`) using concrete evidence from changed files.
+5. Recommend a focused test plan tied directly to changed behavior.
+6. If payload status is `empty`, return a short message saying no semantic analysis is needed.
+7. If payload status is `error`, surface the provided error and do not continue analysis.
+
+## Output Format
+
+Use this exact section structure:
+
+```markdown
+## Semantic Diff Analysis
+
+### Behavioral Impact
+- ...
+
+### API / Schema / Contract Changes
+- ...
+
+### Risk Level
+- Level: <low|medium|high>
+- Why: ...
+
+### Recommended Test Focus
+- ...
+```
+
+Keep output concise and evidence-based. Quote file paths where relevant.

--- a/plugins/compound-learning/commands/semantic-diff.md
+++ b/plugins/compound-learning/commands/semantic-diff.md
@@ -1,0 +1,55 @@
+---
+description: Explain the semantic meaning of local git code changes
+---
+
+# Semantic Diff Command
+
+Explain what a code diff means semantically for behavior, contracts, and risk.
+
+## Usage
+
+```bash
+/semantic-diff
+/semantic-diff --staged
+/semantic-diff --working-tree
+/semantic-diff main..HEAD
+/semantic-diff main...feature-branch
+```
+
+## Your Task
+
+You are the orchestrator.
+
+1. Parse arguments from the user input:
+- No args: default workspace diff (`HEAD` vs current index + working tree)
+- `--staged`: staged-only diff
+- `--working-tree`: unstaged-only diff
+- Any non-flag token: treat as a git range and pass via `--range`
+- Reject conflicting combinations (`range` with staged/working-tree, or staged + working-tree)
+
+2. Run the collector script:
+
+```bash
+python3 [plugin-path]/scripts/semantic-diff.py --cwd "[current-working-directory]" [parsed-args]
+```
+
+3. Parse the returned JSON:
+- If `status == "error"`: show `message` and `hint`, then stop.
+- If `status == "empty"`: show the empty-state guidance and file counts, then stop.
+- If `status == "ok"`: continue.
+
+4. Invoke `semantic-diff-explainer` with the JSON payload and request analysis.
+
+5. Return final output with:
+- A short header line showing mode/range and changed-file counts
+- The explainer's four sections:
+  - Behavioral Impact
+  - API / Schema / Contract Changes
+  - Risk Level
+  - Recommended Test Focus
+
+## Guardrails
+
+- Local git diffs only; do not call GitHub APIs.
+- Keep explanations grounded in the provided patch snippets and stats.
+- If notes indicate truncated patches, mention that confidence may be reduced for omitted context.

--- a/plugins/compound-learning/scripts/semantic-diff.py
+++ b/plugins/compound-learning/scripts/semantic-diff.py
@@ -1,0 +1,691 @@
+#!/usr/bin/env python3
+"""Collect deterministic git diff context for semantic change explanations."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import subprocess
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+
+DEFAULT_UNIFIED_LINES = 6
+DEFAULT_MAX_PATCH_CHARS = 6000
+DEFAULT_MAX_FILES = 60
+
+STATUS_LABELS = {
+    "A": "added",
+    "C": "copied",
+    "D": "deleted",
+    "M": "modified",
+    "R": "renamed",
+    "T": "type-changed",
+    "U": "unmerged",
+    "X": "unknown",
+}
+
+
+@dataclass(frozen=True)
+class DiffSelection:
+    mode: str
+    range_expr: Optional[str] = None
+    base_ref: Optional[str] = None
+    head_ref: Optional[str] = None
+    operator: Optional[str] = None
+
+
+class ArgumentError(ValueError):
+    """Raised when CLI arguments are invalid."""
+
+
+class JsonArgumentParser(argparse.ArgumentParser):
+    """Argparse variant that raises instead of exiting on parse failures."""
+
+    def error(self, message: str) -> None:
+        raise ArgumentError(message)
+
+
+def _decode_text(payload: bytes) -> str:
+    return payload.decode("utf-8", errors="replace")
+
+
+def _run_git(repo_root: str, args: List[str]) -> subprocess.CompletedProcess[bytes]:
+    return subprocess.run(
+        ["git", "-C", repo_root, *args],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def _resolve_repo_root(cwd: str) -> str:
+    probe = subprocess.run(
+        ["git", "-C", cwd, "rev-parse", "--show-toplevel"],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if probe.returncode != 0:
+        raise RuntimeError("Current directory is not inside a git repository.")
+    return _decode_text(probe.stdout).strip()
+
+
+def parse_range_expression(range_expr: str) -> DiffSelection:
+    raw = range_expr.strip()
+    if not raw:
+        raise ArgumentError("Range cannot be empty.")
+
+    if "..." in raw:
+        base, head = raw.split("...", 1)
+        operator = "..."
+        normalized = raw
+    elif ".." in raw:
+        base, head = raw.split("..", 1)
+        operator = ".."
+        normalized = raw
+    else:
+        base = raw
+        head = "HEAD"
+        operator = ".."
+        normalized = f"{base}..{head}"
+
+    if not base or not head:
+        raise ArgumentError(
+            "Invalid range format. Use <base>..<head>, <base>...<head>, or a single base ref."
+        )
+
+    return DiffSelection(
+        mode="range",
+        range_expr=normalized,
+        base_ref=base,
+        head_ref=head,
+        operator=operator,
+    )
+
+
+def resolve_selection(args: argparse.Namespace) -> DiffSelection:
+    if args.range and (args.staged or args.working_tree):
+        raise ArgumentError("Use either --range or --staged/--working-tree, not both.")
+    if args.staged and args.working_tree:
+        raise ArgumentError("Use either --staged or --working-tree, not both.")
+
+    if args.range:
+        return parse_range_expression(args.range)
+    if args.staged:
+        return DiffSelection(mode="staged")
+    if args.working_tree:
+        return DiffSelection(mode="working_tree")
+    return DiffSelection(mode="workspace")
+
+
+def _ref_exists(repo_root: str, ref_name: str) -> bool:
+    probe = _run_git(repo_root, ["rev-parse", "--verify", "--quiet", f"{ref_name}^{{commit}}"])
+    return probe.returncode == 0
+
+
+def validate_selection(repo_root: str, selection: DiffSelection) -> Optional[Dict[str, Any]]:
+    if selection.mode == "range":
+        missing_refs: List[str] = []
+        assert selection.base_ref is not None
+        assert selection.head_ref is not None
+
+        if not _ref_exists(repo_root, selection.base_ref):
+            missing_refs.append(selection.base_ref)
+        if not _ref_exists(repo_root, selection.head_ref):
+            missing_refs.append(selection.head_ref)
+
+        if missing_refs:
+            refs = ", ".join(missing_refs)
+            return error_payload(
+                code="invalid_ref",
+                message=f"Could not resolve git ref(s): {refs}.",
+                mode=selection.mode,
+                hint="Verify refs with `git show <ref>` or use a valid diff range.",
+            )
+        return None
+
+    if selection.mode == "workspace" and not _ref_exists(repo_root, "HEAD"):
+        return error_payload(
+            code="missing_head",
+            message="`HEAD` is not available in this repository yet.",
+            mode=selection.mode,
+            hint="Create the first commit or use --staged/--working-tree explicitly.",
+        )
+
+    return None
+
+
+def build_diff_selector(selection: DiffSelection) -> List[str]:
+    if selection.mode == "range":
+        assert selection.range_expr is not None
+        return [selection.range_expr]
+    if selection.mode == "staged":
+        return ["--cached"]
+    if selection.mode == "working_tree":
+        return []
+    return ["HEAD"]
+
+
+def parse_name_status_z(payload: bytes) -> List[Dict[str, Any]]:
+    tokens = payload.split(b"\x00")
+    if tokens and tokens[-1] == b"":
+        tokens = tokens[:-1]
+
+    rows: List[Dict[str, Any]] = []
+    index = 0
+    while index < len(tokens):
+        raw_status = _decode_text(tokens[index]).strip()
+        index += 1
+        if not raw_status:
+            continue
+
+        status_code = raw_status[0]
+        similarity_text = raw_status[1:]
+        similarity = int(similarity_text) if similarity_text.isdigit() else None
+
+        if status_code in {"R", "C"}:
+            if index + 1 >= len(tokens):
+                break
+            old_path = _decode_text(tokens[index])
+            new_path = _decode_text(tokens[index + 1])
+            index += 2
+            rows.append(
+                {
+                    "path": new_path,
+                    "old_path": old_path,
+                    "status": status_code,
+                    "raw_status": raw_status,
+                    "similarity": similarity,
+                }
+            )
+            continue
+
+        if index >= len(tokens):
+            break
+        path = _decode_text(tokens[index])
+        index += 1
+        rows.append(
+            {
+                "path": path,
+                "old_path": None,
+                "status": status_code,
+                "raw_status": raw_status,
+                "similarity": similarity,
+            }
+        )
+
+    return rows
+
+
+def _parse_num(value: str) -> Optional[int]:
+    if value == "-":
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        return None
+
+
+def parse_numstat_z(payload: bytes) -> Dict[str, Dict[str, Any]]:
+    tokens = payload.split(b"\x00")
+    if tokens and tokens[-1] == b"":
+        tokens = tokens[:-1]
+
+    parsed: Dict[str, Dict[str, Any]] = {}
+    index = 0
+    while index < len(tokens):
+        row = _decode_text(tokens[index])
+        index += 1
+        if not row:
+            continue
+
+        fields = row.split("\t")
+        if len(fields) < 3:
+            continue
+
+        additions_text = fields[0]
+        deletions_text = fields[1]
+        path_field = "\t".join(fields[2:])
+        old_path: Optional[str] = None
+
+        if path_field == "":
+            if index + 1 >= len(tokens):
+                break
+            old_path = _decode_text(tokens[index])
+            path_field = _decode_text(tokens[index + 1])
+            index += 2
+
+        parsed[path_field] = {
+            "additions": _parse_num(additions_text),
+            "deletions": _parse_num(deletions_text),
+            "is_binary": additions_text == "-" or deletions_text == "-",
+            "old_path": old_path,
+        }
+
+    return parsed
+
+
+def _patch_key_from_diff_header(line: str) -> Optional[str]:
+    if not line.startswith("diff --git "):
+        return None
+
+    try:
+        parts = shlex.split(line.strip())
+    except ValueError:
+        return None
+
+    if len(parts) < 4:
+        return None
+
+    left = parts[2]
+    right = parts[3]
+    if left.startswith("a/"):
+        left = left[2:]
+    if right.startswith("b/"):
+        right = right[2:]
+
+    if right == "/dev/null":
+        return left
+    if left == "/dev/null":
+        return right
+    return right
+
+
+def split_patch_sections(patch_text: str) -> Dict[str, str]:
+    sections: Dict[str, str] = {}
+    current_key: Optional[str] = None
+    current_lines: List[str] = []
+
+    for line in patch_text.splitlines(keepends=True):
+        if line.startswith("diff --git "):
+            if current_key is not None and current_lines:
+                chunk = "".join(current_lines)
+                if current_key in sections:
+                    sections[current_key] = f"{sections[current_key]}\n{chunk}"
+                else:
+                    sections[current_key] = chunk
+
+            current_key = _patch_key_from_diff_header(line)
+            current_lines = [line] if current_key else []
+            continue
+
+        if current_key is not None:
+            current_lines.append(line)
+
+    if current_key is not None and current_lines:
+        chunk = "".join(current_lines)
+        if current_key in sections:
+            sections[current_key] = f"{sections[current_key]}\n{chunk}"
+        else:
+            sections[current_key] = chunk
+
+    return sections
+
+
+def truncate_patch(patch_text: str, max_chars: int) -> tuple[str, bool, int]:
+    if len(patch_text) <= max_chars:
+        return patch_text, False, 0
+
+    omitted = len(patch_text) - max_chars
+    marker = f"\n... [truncated {omitted} chars]\n"
+    head_limit = max(0, max_chars - len(marker))
+    return f"{patch_text[:head_limit]}{marker}", True, omitted
+
+
+def error_payload(*, code: str, message: str, mode: str, hint: Optional[str] = None) -> Dict[str, Any]:
+    payload: Dict[str, Any] = {
+        "schema_version": "semantic-diff.v1",
+        "status": "error",
+        "code": code,
+        "mode": mode,
+        "message": message,
+    }
+    if hint:
+        payload["hint"] = hint
+    return payload
+
+
+def _selection_range_payload(selection: DiffSelection) -> Optional[Dict[str, str]]:
+    if selection.mode != "range":
+        return None
+    return {
+        "base": selection.base_ref or "",
+        "head": selection.head_ref or "",
+        "operator": selection.operator or "..",
+        "expression": selection.range_expr or "",
+    }
+
+
+def collect_semantic_diff(
+    *,
+    repo_root: str,
+    selection: DiffSelection,
+    unified_lines: int = DEFAULT_UNIFIED_LINES,
+    max_patch_chars: int = DEFAULT_MAX_PATCH_CHARS,
+    max_files: int = DEFAULT_MAX_FILES,
+) -> Dict[str, Any]:
+    selector = build_diff_selector(selection)
+    git_diff_prefix = ["diff", "--no-ext-diff", "--find-renames=90%"]
+
+    name_status_proc = _run_git(
+        repo_root,
+        [*git_diff_prefix, "--name-status", "-z", *selector],
+    )
+    if name_status_proc.returncode != 0:
+        return error_payload(
+            code="git_diff_failed",
+            message=_decode_text(name_status_proc.stderr).strip() or "git diff failed.",
+            mode=selection.mode,
+            hint="Confirm the repository and diff parameters are valid.",
+        )
+
+    numstat_proc = _run_git(
+        repo_root,
+        [*git_diff_prefix, "--numstat", "-z", *selector],
+    )
+    if numstat_proc.returncode != 0:
+        return error_payload(
+            code="git_numstat_failed",
+            message=_decode_text(numstat_proc.stderr).strip() or "git diff --numstat failed.",
+            mode=selection.mode,
+            hint="Retry with a smaller range or verify repository integrity.",
+        )
+
+    patch_proc = _run_git(
+        repo_root,
+        [*git_diff_prefix, "--patch", "--no-color", f"--unified={unified_lines}", *selector],
+    )
+    if patch_proc.returncode != 0:
+        return error_payload(
+            code="git_patch_failed",
+            message=_decode_text(patch_proc.stderr).strip() or "git diff --patch failed.",
+            mode=selection.mode,
+            hint="Retry with a smaller range or verify repository integrity.",
+        )
+
+    name_rows = parse_name_status_z(name_status_proc.stdout)
+    numstat_map = parse_numstat_z(numstat_proc.stdout)
+    patch_map = split_patch_sections(_decode_text(patch_proc.stdout))
+
+    files_by_path: Dict[str, Dict[str, Any]] = {}
+    for row in name_rows:
+        path = row["path"]
+        files_by_path[path] = {
+            "path": path,
+            "status": row["status"],
+            "change_type": STATUS_LABELS.get(row["status"], "unknown"),
+            "raw_status": row["raw_status"],
+            "old_path": row["old_path"],
+            "similarity": row["similarity"],
+            "additions": 0,
+            "deletions": 0,
+            "is_binary": False,
+            "patch": "",
+            "patch_truncated": False,
+            "patch_chars": 0,
+            "truncated_chars": 0,
+        }
+
+    for path, stats in numstat_map.items():
+        if path not in files_by_path:
+            files_by_path[path] = {
+                "path": path,
+                "status": "M",
+                "change_type": STATUS_LABELS["M"],
+                "raw_status": "M",
+                "old_path": stats.get("old_path"),
+                "similarity": None,
+                "additions": 0,
+                "deletions": 0,
+                "is_binary": False,
+                "patch": "",
+                "patch_truncated": False,
+                "patch_chars": 0,
+                "truncated_chars": 0,
+            }
+
+        files_by_path[path]["additions"] = stats["additions"] if stats["additions"] is not None else 0
+        files_by_path[path]["deletions"] = stats["deletions"] if stats["deletions"] is not None else 0
+        files_by_path[path]["is_binary"] = bool(stats["is_binary"])
+        if files_by_path[path]["old_path"] is None and stats.get("old_path"):
+            files_by_path[path]["old_path"] = stats["old_path"]
+
+    for path, patch_text in patch_map.items():
+        if path not in files_by_path:
+            files_by_path[path] = {
+                "path": path,
+                "status": "M",
+                "change_type": STATUS_LABELS["M"],
+                "raw_status": "M",
+                "old_path": None,
+                "similarity": None,
+                "additions": 0,
+                "deletions": 0,
+                "is_binary": False,
+                "patch": "",
+                "patch_truncated": False,
+                "patch_chars": 0,
+                "truncated_chars": 0,
+            }
+
+        truncated_patch, was_truncated, omitted_chars = truncate_patch(patch_text, max_patch_chars)
+        files_by_path[path]["patch"] = truncated_patch
+        files_by_path[path]["patch_truncated"] = was_truncated
+        files_by_path[path]["patch_chars"] = len(truncated_patch)
+        files_by_path[path]["truncated_chars"] = omitted_chars
+
+    ordered_files = sorted(files_by_path.values(), key=lambda item: item["path"])
+    total_files = len(ordered_files)
+
+    omitted_count = 0
+    if total_files > max_files:
+        omitted_count = total_files - max_files
+        ordered_files = ordered_files[:max_files]
+
+    untracked_proc = _run_git(repo_root, ["ls-files", "--others", "--exclude-standard"])
+    untracked_files = []
+    if untracked_proc.returncode == 0:
+        untracked_files = sorted(
+            [line for line in _decode_text(untracked_proc.stdout).splitlines() if line.strip()]
+        )
+
+    total_insertions = sum(max(0, int(file_row.get("additions") or 0)) for file_row in files_by_path.values())
+    total_deletions = sum(max(0, int(file_row.get("deletions") or 0)) for file_row in files_by_path.values())
+    binary_files = sum(1 for file_row in files_by_path.values() if file_row.get("is_binary"))
+    renamed_files = sum(1 for file_row in files_by_path.values() if file_row.get("status") == "R")
+    truncated_files = sum(1 for file_row in ordered_files if file_row.get("patch_truncated"))
+    status_counts = Counter(file_row.get("status", "M") for file_row in files_by_path.values())
+
+    notes: List[str] = []
+    if omitted_count:
+        notes.append(f"Omitted {omitted_count} file(s) due to --max-files={max_files}.")
+    if untracked_files:
+        notes.append(
+            "Untracked files are listed separately and are not included in git diff output until staged."
+        )
+
+    base_payload: Dict[str, Any] = {
+        "schema_version": "semantic-diff.v1",
+        "status": "ok",
+        "mode": selection.mode,
+        "range": _selection_range_payload(selection),
+        "repo_root": repo_root,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "limits": {
+            "max_files": max_files,
+            "max_patch_chars": max_patch_chars,
+            "unified_lines": unified_lines,
+        },
+        "summary": {
+            "files_changed": total_files,
+            "files_included": len(ordered_files),
+            "files_omitted": omitted_count,
+            "insertions": total_insertions,
+            "deletions": total_deletions,
+            "renamed_files": renamed_files,
+            "binary_files": binary_files,
+            "truncated_patches": truncated_files,
+            "status_counts": dict(sorted(status_counts.items())),
+        },
+        "files": ordered_files,
+        "untracked_files": untracked_files,
+        "notes": notes,
+    }
+
+    if total_files == 0:
+        base_payload["status"] = "empty"
+        base_payload["message"] = (
+            "No tracked code changes detected for the selected diff. "
+            "If you only changed new files, stage them first with `git add`."
+        )
+
+    return base_payload
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = JsonArgumentParser(
+        description=(
+            "Collect structured git diff context for semantic explanation. "
+            "Default mode compares workspace changes against HEAD."
+        )
+    )
+    parser.add_argument(
+        "--range",
+        dest="range",
+        default=None,
+        help="Diff range (<base>..<head>, <base>...<head>, or single <base> to compare against HEAD).",
+    )
+    parser.add_argument(
+        "--staged",
+        action="store_true",
+        help="Compare staged changes against HEAD.",
+    )
+    parser.add_argument(
+        "--working-tree",
+        action="store_true",
+        help="Compare unstaged working tree changes against index.",
+    )
+    parser.add_argument(
+        "--cwd",
+        default=os.getcwd(),
+        help="Directory inside target git repository (default: current working directory).",
+    )
+    parser.add_argument(
+        "--unified",
+        type=int,
+        default=DEFAULT_UNIFIED_LINES,
+        help=f"Unified context lines for patch snippets (default: {DEFAULT_UNIFIED_LINES}).",
+    )
+    parser.add_argument(
+        "--max-patch-chars",
+        type=int,
+        default=DEFAULT_MAX_PATCH_CHARS,
+        help=f"Maximum characters per file patch snippet (default: {DEFAULT_MAX_PATCH_CHARS}).",
+    )
+    parser.add_argument(
+        "--max-files",
+        type=int,
+        default=DEFAULT_MAX_FILES,
+        help=f"Maximum number of files to include in output (default: {DEFAULT_MAX_FILES}).",
+    )
+    return parser
+
+
+def _print_json(payload: Dict[str, Any]) -> None:
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = build_parser()
+    try:
+        args = parser.parse_args(argv)
+    except ArgumentError as exc:
+        _print_json(
+            error_payload(
+                code="invalid_arguments",
+                message=str(exc),
+                mode="unknown",
+                hint="Run with --help to see valid flags and combinations.",
+            )
+        )
+        return 2
+
+    if args.unified < 0:
+        _print_json(
+            error_payload(
+                code="invalid_arguments",
+                message="--unified must be >= 0.",
+                mode="unknown",
+            )
+        )
+        return 2
+
+    if args.max_patch_chars < 200:
+        _print_json(
+            error_payload(
+                code="invalid_arguments",
+                message="--max-patch-chars must be >= 200.",
+                mode="unknown",
+            )
+        )
+        return 2
+
+    if args.max_files < 1:
+        _print_json(
+            error_payload(
+                code="invalid_arguments",
+                message="--max-files must be >= 1.",
+                mode="unknown",
+            )
+        )
+        return 2
+
+    try:
+        selection = resolve_selection(args)
+        repo_root = _resolve_repo_root(args.cwd)
+    except ArgumentError as exc:
+        _print_json(
+            error_payload(
+                code="invalid_arguments",
+                message=str(exc),
+                mode="unknown",
+                hint="Run with --help to see valid flags and combinations.",
+            )
+        )
+        return 2
+    except RuntimeError as exc:
+        _print_json(
+            error_payload(
+                code="not_git_repo",
+                message=str(exc),
+                mode="unknown",
+                hint="Run this command from within a git repository or pass --cwd <repo-path>.",
+            )
+        )
+        return 1
+
+    validation_error = validate_selection(repo_root, selection)
+    if validation_error:
+        _print_json(validation_error)
+        return 1
+
+    payload = collect_semantic_diff(
+        repo_root=repo_root,
+        selection=selection,
+        unified_lines=args.unified,
+        max_patch_chars=args.max_patch_chars,
+        max_files=args.max_files,
+    )
+
+    _print_json(payload)
+    return 1 if payload.get("status") == "error" else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/compound-learning/tests/test_semantic_diff.py
+++ b/plugins/compound-learning/tests/test_semantic_diff.py
@@ -1,0 +1,205 @@
+import importlib.util
+import subprocess
+import sys
+from argparse import Namespace
+from pathlib import Path
+
+
+PLUGIN_ROOT = Path(__file__).parent.parent
+SPEC = importlib.util.spec_from_file_location(
+    "semantic_diff",
+    PLUGIN_ROOT / "scripts" / "semantic-diff.py",
+)
+SEMANTIC_DIFF = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = SEMANTIC_DIFF
+SPEC.loader.exec_module(SEMANTIC_DIFF)
+
+
+def _run(cmd: list[str], cwd: Path) -> str:
+    proc = subprocess.run(
+        cmd,
+        cwd=str(cwd),
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    return proc.stdout.strip()
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir(parents=True, exist_ok=True)
+    _run(["git", "init"], repo)
+    _run(["git", "config", "user.name", "Test User"], repo)
+    _run(["git", "config", "user.email", "test@example.com"], repo)
+
+    (repo / "base.txt").write_text("line-1\n", encoding="utf-8")
+    _run(["git", "add", "base.txt"], repo)
+    _run(["git", "commit", "-m", "initial"], repo)
+    return repo
+
+
+def test_parse_range_expression_variants():
+    two_dot = SEMANTIC_DIFF.parse_range_expression("main..feature")
+    three_dot = SEMANTIC_DIFF.parse_range_expression("main...feature")
+    single_ref = SEMANTIC_DIFF.parse_range_expression("HEAD~2")
+
+    assert two_dot.range_expr == "main..feature"
+    assert two_dot.base_ref == "main"
+    assert two_dot.head_ref == "feature"
+    assert two_dot.operator == ".."
+
+    assert three_dot.range_expr == "main...feature"
+    assert three_dot.base_ref == "main"
+    assert three_dot.head_ref == "feature"
+    assert three_dot.operator == "..."
+
+    assert single_ref.range_expr == "HEAD~2..HEAD"
+    assert single_ref.base_ref == "HEAD~2"
+    assert single_ref.head_ref == "HEAD"
+    assert single_ref.operator == ".."
+
+
+def test_resolve_selection_rejects_conflicting_modes():
+    args = Namespace(range="main..HEAD", staged=True, working_tree=False)
+    try:
+        SEMANTIC_DIFF.resolve_selection(args)
+        assert False, "Expected conflicting mode validation to fail."
+    except SEMANTIC_DIFF.ArgumentError as exc:
+        assert "either --range or --staged/--working-tree" in str(exc)
+
+
+def test_invalid_range_ref_returns_actionable_error(tmp_path):
+    repo = _init_repo(tmp_path)
+    selection = SEMANTIC_DIFF.parse_range_expression("not-a-ref..HEAD")
+
+    error = SEMANTIC_DIFF.validate_selection(str(repo), selection)
+    assert error is not None
+    assert error["status"] == "error"
+    assert error["code"] == "invalid_ref"
+    assert "not-a-ref" in error["message"]
+
+
+def test_no_diff_returns_empty_status(tmp_path):
+    repo = _init_repo(tmp_path)
+    selection = SEMANTIC_DIFF.DiffSelection(mode="workspace")
+
+    payload = SEMANTIC_DIFF.collect_semantic_diff(
+        repo_root=str(repo),
+        selection=selection,
+    )
+
+    assert payload["status"] == "empty"
+    assert payload["summary"]["files_changed"] == 0
+    assert payload["files"] == []
+    assert "stage" in payload["message"]
+
+
+def test_rename_and_numstat_are_captured_for_staged_changes(tmp_path):
+    repo = _init_repo(tmp_path)
+    original = repo / "base.txt"
+    renamed = repo / "renamed.txt"
+    original.rename(renamed)
+
+    _run(["git", "add", "-A"], repo)
+
+    payload = SEMANTIC_DIFF.collect_semantic_diff(
+        repo_root=str(repo),
+        selection=SEMANTIC_DIFF.DiffSelection(mode="staged"),
+    )
+
+    assert payload["status"] == "ok"
+    assert payload["summary"]["files_changed"] == 1
+    assert payload["summary"]["renamed_files"] == 1
+    assert payload["summary"]["status_counts"]["R"] == 1
+
+    file_row = payload["files"][0]
+    assert file_row["status"] == "R"
+    assert file_row["old_path"] == "base.txt"
+    assert file_row["path"] == "renamed.txt"
+    assert file_row["patch"].startswith("diff --git")
+
+
+def test_patch_payload_is_truncated_when_over_limit(tmp_path):
+    repo = _init_repo(tmp_path)
+    large = repo / "large.txt"
+    large.write_text("\n".join(f"old-{idx}" for idx in range(120)) + "\n", encoding="utf-8")
+    _run(["git", "add", "large.txt"], repo)
+    _run(["git", "commit", "-m", "add large"], repo)
+
+    large.write_text("\n".join(f"new-{idx}" for idx in range(120)) + "\n", encoding="utf-8")
+    _run(["git", "add", "large.txt"], repo)
+
+    payload = SEMANTIC_DIFF.collect_semantic_diff(
+        repo_root=str(repo),
+        selection=SEMANTIC_DIFF.DiffSelection(mode="staged"),
+        max_patch_chars=260,
+    )
+
+    assert payload["status"] == "ok"
+    assert payload["summary"]["truncated_patches"] == 1
+    file_row = payload["files"][0]
+    assert file_row["patch_truncated"] is True
+    assert file_row["truncated_chars"] > 0
+    assert "[truncated " in file_row["patch"]
+    assert len(file_row["patch"]) <= 260
+
+
+def test_output_schema_is_stable_for_agent_consumption(tmp_path):
+    repo = _init_repo(tmp_path)
+    tracked = repo / "base.txt"
+    tracked.write_text("line-1\nline-2\n", encoding="utf-8")
+
+    payload = SEMANTIC_DIFF.collect_semantic_diff(
+        repo_root=str(repo),
+        selection=SEMANTIC_DIFF.DiffSelection(mode="working_tree"),
+    )
+
+    required_top_level = {
+        "schema_version",
+        "status",
+        "mode",
+        "range",
+        "repo_root",
+        "generated_at",
+        "limits",
+        "summary",
+        "files",
+        "untracked_files",
+        "notes",
+    }
+    assert required_top_level.issubset(payload.keys())
+    assert payload["schema_version"] == "semantic-diff.v1"
+    assert payload["mode"] == "working_tree"
+
+    summary_keys = {
+        "files_changed",
+        "files_included",
+        "files_omitted",
+        "insertions",
+        "deletions",
+        "renamed_files",
+        "binary_files",
+        "truncated_patches",
+        "status_counts",
+    }
+    assert summary_keys.issubset(payload["summary"].keys())
+
+    assert len(payload["files"]) == 1
+    file_keys = {
+        "path",
+        "status",
+        "change_type",
+        "raw_status",
+        "old_path",
+        "similarity",
+        "additions",
+        "deletions",
+        "is_binary",
+        "patch",
+        "patch_truncated",
+        "patch_chars",
+        "truncated_chars",
+    }
+    assert file_keys.issubset(payload["files"][0].keys())


### PR DESCRIPTION
## Summary
- add a local git-based semantic diff collector script (`scripts/semantic-diff.py`) with deterministic JSON output
- add `/semantic-diff` command orchestration and `semantic-diff-explainer` agent spec
- add tests for range parsing, no-diff behavior, rename/stat extraction, truncation limits, and schema stability
- update plugin docs and bump plugin version to `0.3.3`

## Assumptions
- scope is local repository diffs only (no GitHub API integration)
- default no-arg mode compares workspace changes against `HEAD`
- untracked files are listed separately and excluded from patch output until staged

## Validation
- `pytest plugins/compound-learning/tests/test_semantic_diff.py`
- `pytest -q plugins/compound-learning/tests/test_knowledge_silo_detector.py`
