### PR TITLE
Normalize compound-learning observability taxonomy

### DIFF
--- a/plugins/compound-learning/README.md
+++ b/plugins/compound-learning/README.md
@@ -117,14 +117,30 @@ Threshold precedence and backward compatibility:
 
 ### Observability Events
 
-When observability is enabled, the plugin writes structured JSONL events for:
-- Hooks (`setup`, `auto-peek`, `extract-learnings`) including start/end/skip/subprocess exit/duration
-- Search pipeline (keyword parse, repo scope, fan-out, merge/rerank/filter, threshold buckets, final status)
-- Index pipeline (discovery, per-file failures, prune summary, manifest generation, total runtime)
-- DB operations (connection open, schema init, embeddings, upsert/delete/vector search)
+When observability is enabled, the plugin writes structured JSONL events for setup/auto-peek/extract hooks plus search/index/db Python flows.
 
-Event fields include: `timestamp`, `level`, `component`, `operation`, `status`, `duration_ms`, `counts`, optional `error`, and correlation/session identifiers when available.
-Hooks now export correlation/session context into Python subprocesses so hook events can be joined to search/index/db events in one trace.
+Canonical event contract:
+- Required: `timestamp`, `level`, `component`, `operation`, `status`
+- Optional (standard): `duration_ms`, `counts`, `message`, `error`, `session_id`, `correlation_id`
+- Optional (context/detail): additional emitted fields are preserved for per-event detail
+
+Canonical status set:
+- `start`
+- `success`
+- `error`
+- `skipped`
+- `empty`
+- `degraded`
+
+Operation names are normalized to snake_case. Shared aliases now collapse lifecycle/search variants at emit time:
+- `hook_start` / `hook_end` -> `hook`
+- `extract_start` / `extract_complete` -> `extract`
+- `search_request` / `search_complete` / `search_result` -> `search`
+
+Migration and backward compatibility:
+- When an alias is applied, the original token is preserved as `operation_alias` and/or `status_alias`.
+- Existing detail fields (`counts`, command metadata, scoped context) are retained unchanged.
+- Hooks continue exporting correlation/session context to Python subprocesses so events remain joinable in one trace.
 
 ## Usage
 

--- a/plugins/compound-learning/hooks/observability.sh
+++ b/plugins/compound-learning/hooks/observability.sh
@@ -39,6 +39,68 @@ hook_level_rank() {
   esac
 }
 
+hook_normalize_token() {
+  local raw="${1:-}"
+  local default_value="${2:-unknown}"
+  local normalized
+
+  normalized="$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/_/g; s/^_+//; s/_+$//')"
+  if [ -z "$normalized" ]; then
+    echo "$default_value"
+  else
+    echo "$normalized"
+  fi
+}
+
+hook_normalize_operation() {
+  local normalized
+  normalized="$(hook_normalize_token "$1" "unknown_operation")"
+
+  case "$normalized" in
+    hook_start|hook_end)
+      printf 'hook\t%s\n' "$normalized"
+      ;;
+    extract_start|extract_complete)
+      printf 'extract\t%s\n' "$normalized"
+      ;;
+    search_request|search_complete|search_result)
+      printf 'search\t%s\n' "$normalized"
+      ;;
+    *)
+      printf '%s\t\n' "$normalized"
+      ;;
+  esac
+}
+
+hook_normalize_status() {
+  local normalized
+  normalized="$(hook_normalize_token "$1" "success")"
+
+  case "$normalized" in
+    start|success|error|skipped|empty|degraded)
+      printf '%s\t\n' "$normalized"
+      ;;
+    ok|loaded|found|hit|write)
+      printf 'success\t%s\n' "$normalized"
+      ;;
+    failure|failed|write_failed|exception)
+      printf 'error\t%s\n' "$normalized"
+      ;;
+    bypass)
+      printf 'skipped\t%s\n' "$normalized"
+      ;;
+    miss|missing|not_found)
+      printf 'empty\t%s\n' "$normalized"
+      ;;
+    fallback|stale)
+      printf 'degraded\t%s\n' "$normalized"
+      ;;
+    *)
+      printf 'degraded\t%s\n' "$normalized"
+      ;;
+  esac
+}
+
 hook_expand_home() {
   local raw="$1"
   echo "${raw//\$\{HOME\}/$HOME}"
@@ -170,6 +232,14 @@ hook_obs_event() {
   [ "${HOOK_OBS_ENABLED:-0}" = "1" ] || return 0
   hook_obs_level_allows "$level" || return 0
 
+  local operation_parts
+  local status_parts
+  operation_parts="$(hook_normalize_operation "$operation")"
+  status_parts="$(hook_normalize_status "$status")"
+  local normalized_operation operation_alias normalized_status status_alias
+  IFS=$'\t' read -r normalized_operation operation_alias <<< "$operation_parts"
+  IFS=$'\t' read -r normalized_status status_alias <<< "$status_parts"
+
   local message=""
   local duration_ms=""
   local session_id=""
@@ -225,8 +295,10 @@ hook_obs_event() {
     --arg level "$(hook_normalize_level "$level")" \
     --arg component "hook" \
     --arg hook "${HOOK_NAME:-unknown}" \
-    --arg operation "$operation" \
-    --arg status "$status" \
+    --arg operation "$normalized_operation" \
+    --arg status "$normalized_status" \
+    --arg operation_alias "$operation_alias" \
+    --arg status_alias "$status_alias" \
     --arg message "$message" \
     --arg session_id "$session_id" \
     --arg correlation_id "$correlation_id" \
@@ -243,6 +315,8 @@ hook_obs_event() {
       operation: $operation,
       status: $status
     }
+    + (if ($operation_alias | length) == 0 then {} else {operation_alias: $operation_alias} end)
+    + (if ($status_alias | length) == 0 then {} else {status_alias: $status_alias} end)
     + (if $duration_ms == null then {} else {duration_ms: $duration_ms} end)
     + (if ($message | length) == 0 then {} else {message: $message} end)
     + (if ($session_id | length) == 0 then {} else {session_id: $session_id} end)

--- a/plugins/compound-learning/lib/observability.py
+++ b/plugins/compound-learning/lib/observability.py
@@ -17,6 +17,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Iterable, Iterator, Mapping, MutableMapping, Optional
 
+from lib.observability_taxonomy import normalize_event_taxonomy
+
 try:
     import fcntl
 except ImportError:  # pragma: no cover - fcntl is unavailable on Windows
@@ -254,12 +256,15 @@ class StructuredLogger:
             return
 
         normalized_level = _normalize_level(level)
+        normalized_taxonomy = normalize_event_taxonomy(operation, status)
+        normalized_operation = str(normalized_taxonomy.pop("operation"))
+        normalized_status = str(normalized_taxonomy.pop("status"))
         event: Dict[str, Any] = {
             "timestamp": _now_timestamp(),
             "level": normalized_level,
             "component": self.component,
-            "operation": operation,
-            "status": status,
+            "operation": normalized_operation,
+            "status": normalized_status,
         }
 
         if duration_ms is not None:
@@ -288,6 +293,12 @@ class StructuredLogger:
         extra = _clean_fields(fields)
         if extra:
             event.update(extra)
+
+        # Keep taxonomy keys authoritative even if callers pass colliding fields.
+        event["operation"] = normalized_operation
+        event["status"] = normalized_status
+        for key, value in normalized_taxonomy.items():
+            event[key] = value
 
         try:
             _append_event(self.settings.log_path, event)

--- a/plugins/compound-learning/lib/observability_taxonomy.py
+++ b/plugins/compound-learning/lib/observability_taxonomy.py
@@ -1,0 +1,86 @@
+"""
+Event taxonomy normalization for compound-learning observability.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, Tuple
+
+_TOKEN_PATTERN = re.compile(r"[^a-z0-9]+")
+
+CANONICAL_STATUSES = {
+    "start",
+    "success",
+    "error",
+    "skipped",
+    "empty",
+    "degraded",
+}
+
+STATUS_ALIASES = {
+    "ok": "success",
+    "loaded": "success",
+    "found": "success",
+    "hit": "success",
+    "write": "success",
+    "failure": "error",
+    "failed": "error",
+    "write_failed": "error",
+    "exception": "error",
+    "bypass": "skipped",
+    "miss": "empty",
+    "missing": "empty",
+    "not_found": "empty",
+    "fallback": "degraded",
+    "stale": "degraded",
+}
+
+OPERATION_ALIASES = {
+    "hook_start": "hook",
+    "hook_end": "hook",
+    "extract_start": "extract",
+    "extract_complete": "extract",
+    "search_request": "search",
+    "search_complete": "search",
+    "search_result": "search",
+}
+
+
+def _normalize_token(value: Any, *, default: str) -> str:
+    raw = str(value or "").strip().lower()
+    if not raw:
+        return default
+    normalized = _TOKEN_PATTERN.sub("_", raw).strip("_")
+    return normalized or default
+
+
+def normalize_operation(operation: Any) -> Tuple[str, str | None]:
+    normalized = _normalize_token(operation, default="unknown_operation")
+    canonical = OPERATION_ALIASES.get(normalized, normalized)
+    operation_alias = normalized if canonical != normalized else None
+    return canonical, operation_alias
+
+
+def normalize_status(status: Any) -> Tuple[str, str | None]:
+    normalized = _normalize_token(status, default="success")
+    if normalized in CANONICAL_STATUSES:
+        return normalized, None
+    canonical = STATUS_ALIASES.get(normalized, "degraded")
+    status_alias = normalized if canonical != normalized else None
+    return canonical, status_alias
+
+
+def normalize_event_taxonomy(operation: Any, status: Any) -> Dict[str, Any]:
+    canonical_operation, operation_alias = normalize_operation(operation)
+    canonical_status, status_alias = normalize_status(status)
+
+    fields: Dict[str, Any] = {
+        "operation": canonical_operation,
+        "status": canonical_status,
+    }
+    if operation_alias:
+        fields["operation_alias"] = operation_alias
+    if status_alias:
+        fields["status_alias"] = status_alias
+    return fields

--- a/plugins/compound-learning/tests/test_observability.py
+++ b/plugins/compound-learning/tests/test_observability.py
@@ -7,6 +7,7 @@ PLUGIN_ROOT = Path(__file__).parent.parent
 sys.path.insert(0, str(PLUGIN_ROOT))
 
 import lib.observability as observability
+from lib.observability_taxonomy import CANONICAL_STATUSES
 
 _search_spec = importlib.util.spec_from_file_location(
     "search_learnings",
@@ -71,6 +72,40 @@ def test_level_filtering(tmp_path):
     lines = log_path.read_text(encoding="utf-8").strip().splitlines()
     assert len(lines) == 1
     assert json.loads(lines[0])["level"] == "error"
+
+
+def test_taxonomy_alias_normalization_preserves_legacy_values(tmp_path):
+    log_path = tmp_path / "observability.jsonl"
+    config = {
+        "observability": {
+            "enabled": True,
+            "level": "debug",
+            "logPath": str(log_path),
+        }
+    }
+    logger = observability.get_logger("hook", config)
+    logger.emit("hook_end", "failure", level="error")
+    logger.emit("search_result", "found", level="info")
+
+    events = [
+        json.loads(line)
+        for line in log_path.read_text(encoding="utf-8").strip().splitlines()
+        if line.strip()
+    ]
+    assert len(events) == 2
+
+    first = events[0]
+    assert first["operation"] == "hook"
+    assert first["status"] == "error"
+    assert first["operation_alias"] == "hook_end"
+    assert first["status_alias"] == "failure"
+
+    second = events[1]
+    assert second["operation"] == "search"
+    assert second["status"] == "success"
+    assert second["operation_alias"] == "search_result"
+    assert second["status_alias"] == "found"
+    assert all(event["status"] in CANONICAL_STATUSES for event in events)
 
 
 def test_attach_runtime_context_prefers_hook_env(monkeypatch):

--- a/plugins/compound-learning/tests/test_setup_hook_cache.py
+++ b/plugins/compound-learning/tests/test_setup_hook_cache.py
@@ -1,7 +1,8 @@
+import json
 import os
 import subprocess
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 PLUGIN_ROOT = Path(__file__).parent.parent
 SETUP_SCRIPT = PLUGIN_ROOT / "hooks" / "setup.sh"
@@ -33,7 +34,16 @@ done
     pip_path.chmod(0o755)
 
 
-def _build_env(tmp_path: Path, plugin_root: Path, module_dir: Path, bin_dir: Path) -> Tuple[Dict[str, str], Path, Path]:
+def _build_env(
+    tmp_path: Path,
+    plugin_root: Path,
+    module_dir: Path,
+    bin_dir: Path,
+    *,
+    observability_enabled: bool = False,
+    observability_level: str = "info",
+    observability_log_path: Optional[Path] = None,
+) -> Tuple[Dict[str, str], Path, Path]:
     home_dir = tmp_path / "home"
     home_dir.mkdir(parents=True, exist_ok=True)
     pip_log = tmp_path / "pip.log"
@@ -43,7 +53,10 @@ def _build_env(tmp_path: Path, plugin_root: Path, module_dir: Path, bin_dir: Pat
     env["HOME"] = str(home_dir)
     env["PIP_LOG"] = str(pip_log)
     env["MODULE_DIR"] = str(module_dir)
-    env["LEARNINGS_OBS_ENABLED"] = "false"
+    env["LEARNINGS_OBS_ENABLED"] = "true" if observability_enabled else "false"
+    env["LEARNINGS_OBS_LEVEL"] = observability_level
+    if observability_log_path is not None:
+        env["LEARNINGS_OBS_LOG_PATH"] = str(observability_log_path)
     env["PATH"] = f"{bin_dir}:{env.get('PATH', '')}"
 
     existing_pythonpath = env.get("PYTHONPATH", "")
@@ -71,6 +84,16 @@ def _read_pip_calls(pip_log: Path) -> List[str]:
     if not pip_log.exists():
         return []
     return [line for line in pip_log.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def _read_observability_events(log_path: Path) -> List[Dict[str, object]]:
+    if not log_path.exists():
+        return []
+    return [
+        json.loads(line)
+        for line in log_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
 
 
 def test_setup_cache_hit_validates_and_recovers_from_dependency_drift(tmp_path):
@@ -140,3 +163,44 @@ def test_setup_cache_invalidates_when_manifest_checksum_changes(tmp_path):
     assert "alpha-pkg" not in calls[0]
     assert "beta-pkg" not in calls[0]
     assert len(_cache_stamp_files(home_dir)) == 1
+
+
+def test_setup_hook_observability_uses_canonical_taxonomy(tmp_path):
+    plugin_root = tmp_path / "plugin"
+    module_dir = tmp_path / "modules"
+    bin_dir = tmp_path / "bin"
+    module_dir.mkdir(parents=True, exist_ok=True)
+    bin_dir.mkdir(parents=True, exist_ok=True)
+
+    _write_runtime_manifest(plugin_root, ["alpha-pkg", "beta-pkg"])
+    (module_dir / "alpha_pkg.py").write_text("ALPHA = True\n", encoding="utf-8")
+    _write_fake_pip(bin_dir)
+
+    observability_log_path = tmp_path / "observability.jsonl"
+    env, _home_dir, _pip_log = _build_env(
+        tmp_path,
+        plugin_root,
+        module_dir,
+        bin_dir,
+        observability_enabled=True,
+        observability_level="debug",
+        observability_log_path=observability_log_path,
+    )
+
+    run = _run_setup(env)
+    assert run.returncode == 0
+
+    events = _read_observability_events(observability_log_path)
+    assert events
+
+    required_keys = {"timestamp", "level", "component", "operation", "status"}
+    canonical_statuses = {"start", "success", "error", "skipped", "empty", "degraded"}
+    legacy_statuses = {"failure", "found", "loaded", "bypass", "hit", "miss", "missing", "stale", "write", "write_failed", "fallback"}
+
+    assert all(required_keys.issubset(event.keys()) for event in events)
+    assert all(event["component"] == "hook" for event in events)
+    assert all(event.get("hook") == "setup" for event in events)
+    assert all(event["status"] in canonical_statuses for event in events)
+    assert all(event["status"] not in legacy_statuses for event in events)
+    assert any(event["operation"] == "hook" and event.get("operation_alias") in {"hook_start", "hook_end"} for event in events)
+    assert any(event.get("status_alias") for event in events)


### PR DESCRIPTION
## Summary
- add centralized taxonomy helpers in `lib/observability_taxonomy.py` for operation/status normalization
- normalize all Python `StructuredLogger.emit()` events at write-time (canonical operation/status + alias preservation)
- normalize hook events in `hooks/observability.sh` with matching taxonomy behavior
- document canonical observability contract in plugin README
- extend Python + setup hook tests to validate canonical taxonomy and backward-compatible alias fields

## Compatibility behavior
- canonical statuses now emit as: `start`, `success`, `error`, `skipped`, `empty`, `degraded`
- lifecycle/search operation aliases are normalized (`hook_*` -> `hook`, `extract_*` -> `extract`, `search_*` -> `search`)
- when alias mapping occurs, original tokens are preserved via `operation_alias` / `status_alias`
- detail fields (`counts`, context, command metadata) are retained

## Verification
- `pytest plugins/compound-learning/tests/test_observability.py plugins/compound-learning/tests/test_setup_hook_cache.py`