### PR TITLE
Event taxonomy normalizer: edge-case fixes

### DIFF
--- a/plugins/compound-learning/README.md
+++ b/plugins/compound-learning/README.md
@@ -139,6 +139,8 @@ Operation names are normalized to snake_case. Shared aliases now collapse lifecy
 
 Migration and backward compatibility:
 - When an alias is applied, the original token is preserved as `operation_alias` and/or `status_alias`.
+- Empty-result aliases (`miss`, `missing`, `not_found`, `no_results`) normalize to canonical `empty`.
+- Canonical taxonomy fields stay authoritative even when additional payload fields include colliding taxonomy keys.
 - Existing detail fields (`counts`, command metadata, scoped context) are retained unchanged.
 - Hooks continue exporting correlation/session context to Python subprocesses so events remain joinable in one trace.
 

--- a/plugins/compound-learning/hooks/observability.sh
+++ b/plugins/compound-learning/hooks/observability.sh
@@ -89,7 +89,7 @@ hook_normalize_status() {
     bypass)
       printf 'skipped\t%s\n' "$normalized"
       ;;
-    miss|missing|not_found)
+    miss|missing|not_found|no_results)
       printf 'empty\t%s\n' "$normalized"
       ;;
     fallback|stale)
@@ -323,7 +323,7 @@ hook_obs_event() {
     + (if ($correlation_id | length) == 0 then {} else {correlation_id: $correlation_id} end)
     + (if $counts == null then {} else {counts: $counts} end)
     + (if $error == null then {} else {error: $error} end)
-    + (if $extra == null then {} else $extra end)
+    + (if $extra == null then {} else ($extra | del(.operation, .status, .operation_alias, .status_alias)) end)
     ' 2>/dev/null)
 
   [ -n "$event" ] || return 0

--- a/plugins/compound-learning/lib/observability.py
+++ b/plugins/compound-learning/lib/observability.py
@@ -295,6 +295,8 @@ class StructuredLogger:
             event.update(extra)
 
         # Keep taxonomy keys authoritative even if callers pass colliding fields.
+        event.pop("operation_alias", None)
+        event.pop("status_alias", None)
         event["operation"] = normalized_operation
         event["status"] = normalized_status
         for key, value in normalized_taxonomy.items():

--- a/plugins/compound-learning/lib/observability_taxonomy.py
+++ b/plugins/compound-learning/lib/observability_taxonomy.py
@@ -32,6 +32,7 @@ STATUS_ALIASES = {
     "miss": "empty",
     "missing": "empty",
     "not_found": "empty",
+    "no_results": "empty",
     "fallback": "degraded",
     "stale": "degraded",
 }

--- a/plugins/compound-learning/tests/test_observability.py
+++ b/plugins/compound-learning/tests/test_observability.py
@@ -108,6 +108,50 @@ def test_taxonomy_alias_normalization_preserves_legacy_values(tmp_path):
     assert all(event["status"] in CANONICAL_STATUSES for event in events)
 
 
+def test_taxonomy_maps_search_no_results_to_empty(tmp_path):
+    log_path = tmp_path / "observability.jsonl"
+    config = {
+        "observability": {
+            "enabled": True,
+            "level": "debug",
+            "logPath": str(log_path),
+        }
+    }
+    logger = observability.get_logger("search", config)
+    logger.emit("search_complete", "no_results", level="info")
+
+    event = json.loads(log_path.read_text(encoding="utf-8").strip())
+    assert event["operation"] == "search"
+    assert event["status"] == "empty"
+    assert event["operation_alias"] == "search_complete"
+    assert event["status_alias"] == "no_results"
+
+
+def test_canonical_taxonomy_clears_injected_alias_fields(tmp_path):
+    log_path = tmp_path / "observability.jsonl"
+    config = {
+        "observability": {
+            "enabled": True,
+            "level": "debug",
+            "logPath": str(log_path),
+        }
+    }
+    logger = observability.get_logger("db", config)
+    logger.emit(
+        "vector_search",
+        "success",
+        level="info",
+        operation_alias="caller_alias",
+        status_alias="caller_status_alias",
+    )
+
+    event = json.loads(log_path.read_text(encoding="utf-8").strip())
+    assert event["operation"] == "vector_search"
+    assert event["status"] == "success"
+    assert "operation_alias" not in event
+    assert "status_alias" not in event
+
+
 def test_attach_runtime_context_prefers_hook_env(monkeypatch):
     config = {
         "observability": {

--- a/plugins/compound-learning/tests/test_setup_hook_cache.py
+++ b/plugins/compound-learning/tests/test_setup_hook_cache.py
@@ -96,6 +96,51 @@ def _read_observability_events(log_path: Path) -> List[Dict[str, object]]:
     ]
 
 
+def _emit_hook_event(
+    tmp_path: Path,
+    *,
+    operation: str,
+    status: str,
+    extra_json: Optional[str] = None,
+) -> List[Dict[str, object]]:
+    home_dir = tmp_path / "hook-home"
+    home_dir.mkdir(parents=True, exist_ok=True)
+    log_path = tmp_path / "hook-observability.jsonl"
+
+    env = os.environ.copy()
+    env["HOME"] = str(home_dir)
+    env["CLAUDE_PLUGIN_ROOT"] = str(PLUGIN_ROOT)
+    env["LEARNINGS_OBS_ENABLED"] = "true"
+    env["LEARNINGS_OBS_LEVEL"] = "debug"
+    env["LEARNINGS_OBS_LOG_PATH"] = str(log_path)
+    env["HOOK_EVENT_OPERATION"] = operation
+    env["HOOK_EVENT_STATUS"] = status
+    if extra_json is not None:
+        env["HOOK_EVENT_EXTRA_JSON"] = extra_json
+    else:
+        env.pop("HOOK_EVENT_EXTRA_JSON", None)
+
+    script = f"""
+set -euo pipefail
+source "{PLUGIN_ROOT / "hooks" / "observability.sh"}"
+hook_log_init "setup"
+if [ -n "${{HOOK_EVENT_EXTRA_JSON:-}}" ]; then
+  hook_obs_event "info" "$HOOK_EVENT_OPERATION" "$HOOK_EVENT_STATUS" --session-id "sess-test" --extra-json "$HOOK_EVENT_EXTRA_JSON"
+else
+  hook_obs_event "info" "$HOOK_EVENT_OPERATION" "$HOOK_EVENT_STATUS" --session-id "sess-test"
+fi
+"""
+    run = subprocess.run(
+        ["bash", "-lc", script],
+        capture_output=True,
+        check=False,
+        env=env,
+        text=True,
+    )
+    assert run.returncode == 0, run.stderr
+    return _read_observability_events(log_path)
+
+
 def test_setup_cache_hit_validates_and_recovers_from_dependency_drift(tmp_path):
     plugin_root = tmp_path / "plugin"
     module_dir = tmp_path / "modules"
@@ -204,3 +249,35 @@ def test_setup_hook_observability_uses_canonical_taxonomy(tmp_path):
     assert all(event["status"] not in legacy_statuses for event in events)
     assert any(event["operation"] == "hook" and event.get("operation_alias") in {"hook_start", "hook_end"} for event in events)
     assert any(event.get("status_alias") for event in events)
+
+
+def test_hook_observability_extra_json_cannot_override_taxonomy(tmp_path):
+    events = _emit_hook_event(
+        tmp_path,
+        operation="hook_end",
+        status="failure",
+        extra_json='{"operation":"override","status":"success","operation_alias":"bad","status_alias":"bad","detail":"kept"}',
+    )
+
+    assert len(events) == 1
+    event = events[0]
+    assert event["operation"] == "hook"
+    assert event["status"] == "error"
+    assert event["operation_alias"] == "hook_end"
+    assert event["status_alias"] == "failure"
+    assert event["detail"] == "kept"
+
+
+def test_hook_observability_maps_no_results_status_to_empty(tmp_path):
+    events = _emit_hook_event(
+        tmp_path,
+        operation="search_complete",
+        status="no_results",
+    )
+
+    assert len(events) == 1
+    event = events[0]
+    assert event["operation"] == "search"
+    assert event["status"] == "empty"
+    assert event["operation_alias"] == "search_complete"
+    assert event["status_alias"] == "no_results"


### PR DESCRIPTION
## Summary
- carry forward the shared observability taxonomy normalization from iteration 1 (Python + hook emit points)
- fix `search_complete` empty-result normalization by mapping `no_results` to canonical `empty`
- make hook taxonomy fields authoritative by preventing `--extra-json` from overriding `operation`/`status`/alias keys
- make Python taxonomy aliases authoritative by clearing caller-injected alias keys before applying normalized taxonomy
- add regression tests for `no_results` normalization and taxonomy override protection in both Python and hook coverage

## Compatibility
- canonical event shape remains stable (`timestamp`, `level`, `component`, `operation`, `status`, optional standard fields)
- alias preservation remains backward compatible (`operation_alias` / `status_alias`) when normalization applies
- detail fields in extra payloads are preserved except colliding taxonomy keys

## Verification
- `pytest plugins/compound-learning/tests/test_observability.py plugins/compound-learning/tests/test_setup_hook_cache.py`
- `pytest plugins/compound-learning/tests`
