### PR TITLE
Fix skill-root script paths in compound-learning skills

### DIFF
--- a/plugins/compound-learning/commands/consolidate-learnings.md
+++ b/plugins/compound-learning/commands/consolidate-learnings.md
@@ -21,7 +21,7 @@ You orchestrate a three-phase workflow: Discovery -> Approval -> Parallel Execut
 Run the discovery skill:
 
 ```bash
-python3 [plugin-path]/skills/consolidate-discovery/consolidate-discovery.py --mode all 2>/dev/null
+python3 skills/consolidate-discovery/consolidate-discovery.py --mode all 2>/dev/null
 ```
 
 Parse the JSON output to build your report.
@@ -70,7 +70,8 @@ Approve this plan? (You can request modifications first)
 ```
 
 **Important for report:**
-- Use `python3 [plugin-path]/skills/consolidate-actions/consolidate-actions.py get --ids=...` to fetch content if needed to understand WHY files should be merged
+- Run script commands from the plugin root (`plugins/compound-learning`)
+- Use `python3 skills/consolidate-actions/consolidate-actions.py get --ids=...` to fetch content if needed to understand WHY files should be merged
 - Group name should be descriptive (e.g., "jwt-authentication", "helm-deployment-patterns")
 - **CRITICAL: Deletions must EXCLUDE files that appear in any merge group** - those get deleted automatically by the merge operation
 - Only list truly orphaned outdated files in the Deletions section
@@ -85,10 +86,10 @@ After user approval, launch sub-agents in parallel:
 Each sub-agent runs:
 ```bash
 # Merge sub-agent
-python3 [plugin-path]/skills/consolidate-actions/consolidate-actions.py merge --ids=id1,id2 --name=group-name
+python3 skills/consolidate-actions/consolidate-actions.py merge --ids=id1,id2 --name=group-name
 
 # Deletion sub-agent
-python3 [plugin-path]/skills/consolidate-actions/consolidate-actions.py delete --ids=id1,id2,id3
+python3 skills/consolidate-actions/consolidate-actions.py delete --ids=id1,id2,id3
 ```
 
 ### Phase 4: Report Results

--- a/plugins/compound-learning/commands/knowledge-silo-detector.md
+++ b/plugins/compound-learning/commands/knowledge-silo-detector.md
@@ -17,13 +17,13 @@ Analyze indexed learnings for concentration risk by topic.
 1. Run the detector in human-readable mode:
 
 ```bash
-python3 [plugin-path]/scripts/detect-knowledge-silos.py --format text
+python3 scripts/detect-knowledge-silos.py --format text
 ```
 
 2. If the user requests machine-readable output or automation, run:
 
 ```bash
-python3 [plugin-path]/scripts/detect-knowledge-silos.py --format json
+python3 scripts/detect-knowledge-silos.py --format json
 ```
 
 3. Present results using this structure:
@@ -57,15 +57,18 @@ Assumption: repository scope approximates team/domain boundaries when explicit t
 Pass thresholds explicitly when requested:
 
 ```bash
-python3 [plugin-path]/scripts/detect-knowledge-silos.py \
+python3 scripts/detect-knowledge-silos.py \
   --min-topic-samples 5 \
   --repo-dominance-threshold 0.75 \
   --author-dominance-threshold 0.70 \
   --format text
 ```
 
+Run these script commands from the plugin root (`plugins/compound-learning`).
+
 ## Guardrails
 
 - Read-only analysis only. Do not modify indexed learnings or source files.
 - Keep findings sorted by risk score.
 - Include recommendations for each finding.
+- Treat `global` scope as cross-cutting context, not a repo/team; exclude it from repo dominance scoring.

--- a/plugins/compound-learning/skills/consolidate-actions/SKILL.md
+++ b/plugins/compound-learning/skills/consolidate-actions/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: consolidate-actions
-description: Execute approved consolidation actions (merge, archive, delete, rescope, get). Use after review and user approval.
+description: Execute approved learning-consolidation actions (get, merge, archive, delete, rescope) against indexed learnings. Use only after the user approves a consolidation plan.
 ---
 
 # Consolidate Actions
@@ -9,30 +9,36 @@ Execute consolidation operations on learnings. All destructive operations create
 
 ## Usage
 
+Preferred workflow:
+
 ```bash
-# Fetch full content for review
-python3 [plugin-path]/skills/consolidate-actions/consolidate-actions.py get --ids=id1,id2
-
-# Delete with backup
-python3 [plugin-path]/skills/consolidate-actions/consolidate-actions.py delete --ids=id1,id2
-
-# Move to archive
-python3 [plugin-path]/skills/consolidate-actions/consolidate-actions.py archive --ids=id1,id2
-
-# Change scope (repo -> global)
-python3 [plugin-path]/skills/consolidate-actions/consolidate-actions.py rescope --id=abc123 --scope=global
-
-# Merge multiple into one
-python3 [plugin-path]/skills/consolidate-actions/consolidate-actions.py merge --ids=id1,id2,id3 --name=jwt-patterns
-
-# Merge with explicit output directory (overrides scope logic)
-python3 [plugin-path]/skills/consolidate-actions/consolidate-actions.py merge --ids=id1,id2 --name=patterns --output-dir=/absolute/path/to/repo/.projects/learnings
-
-# Dry run (show what would happen)
-python3 [plugin-path]/skills/consolidate-actions/consolidate-actions.py merge --ids=id1,id2 --name=patterns --dry-run
+/consolidate-learnings
 ```
 
-`[plugin-path]` is the absolute path to this plugin root (the directory containing `commands/` and `skills/`).
+Direct script usage (run from this skill directory):
+
+```bash
+# Fetch full content for review
+python3 consolidate-actions.py get --ids=id1,id2
+
+# Delete with backup
+python3 consolidate-actions.py delete --ids=id1,id2
+
+# Move to archive
+python3 consolidate-actions.py archive --ids=id1,id2
+
+# Change scope (repo -> global)
+python3 consolidate-actions.py rescope --id=abc123 --scope=global
+
+# Merge multiple into one
+python3 consolidate-actions.py merge --ids=id1,id2,id3 --name=jwt-patterns
+
+# Merge with explicit output directory (overrides scope logic)
+python3 consolidate-actions.py merge --ids=id1,id2 --name=patterns --output-dir=/absolute/path/to/repo/.projects/learnings
+
+# Dry run (show what would happen)
+python3 consolidate-actions.py merge --ids=id1,id2 --name=patterns --dry-run
+```
 
 ## Actions
 

--- a/plugins/compound-learning/skills/consolidate-discovery/SKILL.md
+++ b/plugins/compound-learning/skills/consolidate-discovery/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: consolidate-discovery
-description: Find duplicate and outdated learnings in SQLite. Use before proposing or running consolidation actions.
+description: Find duplicate and outdated learnings in the SQLite index and return compact JSON candidates. Use before proposing merge/delete consolidation actions.
 ---
 
 # Consolidate Discovery
@@ -9,11 +9,17 @@ Discovers learnings that may need consolidation: duplicates and outdated content
 
 ## Usage
 
+Preferred workflow:
+
 ```bash
-python3 [plugin-path]/skills/consolidate-discovery/consolidate-discovery.py [--mode all|duplicates|outdated] [--limit N]
+/consolidate-learnings
 ```
 
-`[plugin-path]` is the absolute path to this plugin root (the directory containing `commands/` and `skills/`).
+Direct script usage (run from this skill directory):
+
+```bash
+python3 consolidate-discovery.py [--mode all|duplicates|outdated] [--limit N]
+```
 
 ## Options
 
@@ -52,4 +58,4 @@ Compact JSON with file basenames, paths, and IDs:
 
 - Uses tight similarity threshold (0.25) for true duplicates
 - Output is compact to avoid token bloat
-- Use `python3 [plugin-path]/skills/consolidate-actions/consolidate-actions.py get --ids=...` to fetch full content when needed
+- Use `python3 ../consolidate-actions/consolidate-actions.py get --ids=...` to fetch full content when needed

--- a/plugins/compound-learning/skills/index-learnings/SKILL.md
+++ b/plugins/compound-learning/skills/index-learnings/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: index-learnings
-description: Build or refresh the learnings SQLite index and topic manifest. Use when new or updated learnings need to be searchable.
+description: Build or refresh the learnings SQLite index and regenerate MANIFEST.md topic summaries. Use after adding or updating learnings, or before search and analysis commands.
 ---
 
 # Index Learnings
@@ -15,14 +15,12 @@ Preferred:
 /index-learnings
 ```
 
-Direct script (if command routing is unavailable):
+Direct script (if command routing is unavailable; run from this skill directory):
 
 ```bash
-python3 [plugin-path]/skills/index-learnings/index-learnings.py
-python3 [plugin-path]/skills/index-learnings/index-learnings.py --file /absolute/path/to/learning.md
+python3 index-learnings.py
+python3 index-learnings.py --file /absolute/path/to/learning.md
 ```
-
-`[plugin-path]` is the absolute path to this plugin root (the directory containing `commands/` and `skills/`).
 
 ## What It Does
 


### PR DESCRIPTION
## Summary
- Fetched `https://agentskills.io/llms.txt` first, then validated naming/frontmatter/path rules from `https://agentskills.io/specification.md` (plus script-path behavior from `https://agentskills.io/skill-creation/using-scripts.md`).
- Audited for `.claude/skills` and `.codex/skills` SKILL files in this repo: none found; continued with the concrete local scope in `plugins/compound-learning/skills`.
- Fixed the SKILL path regressions by making script examples skill-root-relative (`python3 <local-script>.py`), including sibling reference from discovery to actions.
- Kept command docs aligned with plugin-root workflow by replacing stale `[plugin-path]` placeholders with explicit plugin-root-relative commands.

## Validation
- Frontmatter check across all audited skill files: required `name`/`description`, name pattern constraints, and directory-name match all pass.
- Script-reference check across audited skills: all referenced Python paths resolve.
- Smoke tests:
  - `cd plugins/compound-learning/skills/consolidate-actions && python3 consolidate-actions.py --help`
  - `cd plugins/compound-learning/skills/consolidate-discovery && python3 consolidate-discovery.py --help`
  - `cd plugins/compound-learning/skills/index-learnings && python3 index-learnings.py --help`
- Full tests: `pytest -q` -> `23 passed, 8 skipped`.

## Follow-ups
- If this repo should eventually host project-local wrappers under `.claude/skills` or `.codex/skills`, add a documented convention in root `README.md` (or AGENTS.md) so future grooming can validate those locations explicitly.
