### PR TITLE
Fix transcript context extractor crash on mixed content blocks

### DIFF
--- a/plugins/compound-learning/hooks/extract-transcript-context.py
+++ b/plugins/compound-learning/hooks/extract-transcript-context.py
@@ -10,15 +10,43 @@ Output is truncated to a reasonable size for fast Haiku processing.
 
 import json
 import sys
+from typing import Iterator
 
 
 def is_real_user_prompt(entry: dict) -> bool:
     """Check if entry is a real user prompt (not a tool_result)."""
+    if not isinstance(entry, dict):
+        return False
     if entry.get('type') != 'user':
         return False
-    content = entry.get('message', {}).get('content')
+    message = entry.get('message', {})
+    if not isinstance(message, dict):
+        return False
+    content = message.get('content')
     # Real user prompts have string content, tool results have array content
     return isinstance(content, str)
+
+
+def iter_assistant_text(content) -> Iterator[str]:
+    """Yield assistant text blocks from supported transcript content shapes."""
+    if isinstance(content, str):
+        yield content
+        return
+
+    if not isinstance(content, list):
+        return
+
+    for item in content:
+        if isinstance(item, str):
+            yield item
+            continue
+        if not isinstance(item, dict):
+            continue
+        if item.get('type') != 'text':
+            continue
+        text = item.get('text', '')
+        if isinstance(text, str):
+            yield text
 
 
 def extract_context(transcript_path: str, max_chars: int = 3000) -> str:
@@ -38,6 +66,8 @@ def extract_context(transcript_path: str, max_chars: int = 3000) -> str:
         try:
             entry = json.loads(line)
         except json.JSONDecodeError:
+            continue
+        if not isinstance(entry, dict):
             continue
 
         entry_type = entry.get('type')
@@ -60,21 +90,21 @@ def extract_context(transcript_path: str, max_chars: int = 3000) -> str:
 
         # Extract text from assistant messages
         message = entry.get('message', {})
+        if not isinstance(message, dict):
+            continue
         content = message.get('content', [])
 
-        if isinstance(content, list):
-            for item in content:
-                if item.get('type') == 'text':
-                    text = item.get('text', '')
-                    if text and total_chars + len(text) <= max_chars:
-                        context_parts.append(text)
-                        total_chars += len(text)
-                    elif text:
-                        # Truncate to fit
-                        remaining = max_chars - total_chars
-                        if remaining > 100:
-                            context_parts.append(text[:remaining] + "...")
-                        break
+        for text in iter_assistant_text(content):
+            if text and total_chars + len(text) <= max_chars:
+                context_parts.append(text)
+                total_chars += len(text)
+            elif text:
+                # Truncate to fit
+                remaining = max_chars - total_chars
+                if remaining > 100:
+                    context_parts.append(text[:remaining] + "...")
+                total_chars = max_chars
+                break
 
         if total_chars >= max_chars:
             break

--- a/plugins/compound-learning/tests/test_extract_transcript_context.py
+++ b/plugins/compound-learning/tests/test_extract_transcript_context.py
@@ -1,0 +1,87 @@
+import importlib.util
+import json
+from pathlib import Path
+
+PLUGIN_ROOT = Path(__file__).parent.parent
+
+_context_spec = importlib.util.spec_from_file_location(
+    "extract_transcript_context",
+    PLUGIN_ROOT / "hooks" / "extract-transcript-context.py",
+)
+context_module = importlib.util.module_from_spec(_context_spec)
+_context_spec.loader.exec_module(context_module)
+
+
+def _write_jsonl(path: Path, records):
+    with open(path, "w", encoding="utf-8") as handle:
+        for record in records:
+            if isinstance(record, str):
+                handle.write(record + "\n")
+            else:
+                handle.write(json.dumps(record) + "\n")
+
+
+def test_extract_context_handles_mixed_string_and_dict_blocks(tmp_path):
+    transcript = tmp_path / "transcript.jsonl"
+    _write_jsonl(
+        transcript,
+        [
+            {"type": "user", "message": {"content": "older prompt"}},
+            {
+                "type": "assistant",
+                "message": {"content": ["string block", {"type": "text", "text": "dict block"}]},
+            },
+            {"type": "user", "message": {"content": "latest prompt"}},
+        ],
+    )
+
+    context = context_module.extract_context(str(transcript))
+
+    assert "string block" in context
+    assert "dict block" in context
+
+
+def test_extract_context_skips_malformed_jsonl_lines(tmp_path):
+    transcript = tmp_path / "transcript.jsonl"
+    _write_jsonl(
+        transcript,
+        [
+            {"type": "user", "message": {"content": "older prompt"}},
+            "this is not valid json",
+            {"type": "assistant", "message": {"content": [{"type": "text", "text": "safe text"}]}},
+            '{"type":"assistant","message":',
+            {"type": "user", "message": {"content": "latest prompt"}},
+        ],
+    )
+
+    context = context_module.extract_context(str(transcript))
+
+    assert context == "safe text"
+
+
+def test_extract_context_ignores_unexpected_content_item_types(tmp_path):
+    transcript = tmp_path / "transcript.jsonl"
+    _write_jsonl(
+        transcript,
+        [
+            {"type": "user", "message": {"content": "older prompt"}},
+            {
+                "type": "assistant",
+                "message": {
+                    "content": [
+                        7,
+                        None,
+                        {"type": "tool_use", "name": "bash"},
+                        {"type": "text", "text": 123},
+                        {"type": "text", "text": "valid text"},
+                        True,
+                    ]
+                },
+            },
+            {"type": "user", "message": {"content": "latest prompt"}},
+        ],
+    )
+
+    context = context_module.extract_context(str(transcript))
+
+    assert context == "valid text"


### PR DESCRIPTION
## Summary
- add regression tests for `extract-transcript-context.py` covering mixed string/dict assistant blocks
- add edge-case coverage for malformed JSONL lines and unsupported assistant content item types
- harden assistant content parsing so string blocks and dict text blocks are handled safely without calling `.get` on non-dicts

## Reproduction
Before this change, a transcript entry like:

```json
{"type":"assistant","message":{"content":["plain text",{"type":"text","text":"more"}]}}
```

could crash `extract_context()` with `AttributeError: 'str' object has no attribute 'get'`.

## Fix
- guard parsed transcript entries and message payloads before dict access
- introduce `iter_assistant_text()` to normalize supported assistant content shapes:
  - plain string content
  - list entries that are either strings or `{"type": "text", "text": ...}` blocks
- skip unsupported shapes/types gracefully
- keep context extraction boundaries, chronological output, and truncation behavior

## Test Evidence
- `pytest -q plugins/compound-learning/tests/test_extract_transcript_context.py` -> `3 passed`
- `pytest -q` -> `26 passed, 8 skipped`
