### PR TITLE
chore: initialize td review workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 *.pyc
 activity.log
 
+.todos/


### PR DESCRIPTION
## Summary
- initialized td for this repository (`td init`) and started review session/work session (`td-review-20260307`)
- queried review queues (`td in-review`, `td reviewable`, `td list --status in_review --json`) and found no open review issues
- logged review sweep in td work session
- added `.todos/` to `.gitignore` to keep td DB local-only artifacts out of git

## Follow-up Issue
- created `td-d485a8` for a larger pre-existing test-environment failure discovered during validation (`pytest -q plugins/compound-learning/tests/test_search_relevance.py`)

## Validation
- `pytest -q plugins/compound-learning/tests/test_search_relevance.py` (fails in current environment due `torchvision::nms`/`transformers` import mismatch; tracked in `td-d485a8`)
