### PR TITLE
Add compound-learning doc drift detector

### DIFF
--- a/plugins/compound-learning/README.md
+++ b/plugins/compound-learning/README.md
@@ -158,9 +158,12 @@ Fetches PR data including reviews, comments, and code changes, then extracts 1-3
 
 ### Searching Learnings
 
-Learnings are automatically searched at the start of tasks. To manually search:
-```
-Skill(skill="search-learnings", args="JWT authentication patterns")
+Learnings are automatically searched on `UserPromptSubmit` by `hooks/auto-peek.sh`, which calls `scripts/search-learnings.py`.
+
+For a manual check from the repository root:
+
+```bash
+python3 plugins/compound-learning/scripts/search-learnings.py "JWT authentication patterns" "$(pwd)" --max-results 5
 ```
 
 ### Rebuilding the Index
@@ -221,22 +224,24 @@ Generated: 2026-02-03T14:30:00Z
 
 Topics come from `**Topic:**` and `**Tags:**` fields in learning files. `**Type:** gotcha` learnings are flagged with ⚠️.
 
-### Auto-Extraction via Hooks
+### Automation via Hooks
 
-The plugin automatically extracts learnings at key moments:
+The plugin wiring is defined in `hooks/hooks.json`:
 
-- **PreCompact**: Before context compaction to preserve insights
-- **Stop**: When Claude finishes responding
+- **SessionStart**: Runs `hooks/setup.sh` to install dependencies and initialize runtime
+- **SessionEnd**: Runs `hooks/extract-learnings.sh` asynchronously after the session
+- **PreCompact**: Runs `hooks/extract-learnings.sh` before context compaction
+- **UserPromptSubmit**: Runs `hooks/auto-peek.sh` to surface relevant learnings
 
 How it works:
-1. Hooks trigger `extract-learnings.sh` which invokes `claude -p` to analyze the transcript
+1. Extraction hooks trigger `hooks/extract-learnings.sh`, which invokes `claude -p` to analyze the transcript
 2. Claude reads the conversation transcript and identifies 0-3 meaningful learnings
 3. Learning files are written to the appropriate scope (global or repo)
-4. Session tracking files (`~/.claude/plugins/compound-learning/sessions/*.seen`) prevent duplicate surfacing within a session window
+4. User-prompt peeks track seen IDs in `~/.claude/plugins/compound-learning/sessions/*.seen`
 
 **Debug log:** `~/.claude/plugins/compound-learning/activity.log`
 
-**Note:** Extraction uses minimal permissions (`Write`, `Bash(mkdir:*)`) and skips trivial sessions (<20 transcript lines).
+**Note:** Extraction uses minimal permissions (`Read`, `Write`, `Bash(mkdir:*)`) and skips trivial sessions (<20 transcript lines).
 
 ## Architecture
 
@@ -254,21 +259,22 @@ How it works:
   - `pr-learning-extractor`: Analyzes GitHub PRs and extracts learnings from reviews
 
 - **Skills:**
-  - `search-learnings`: Queries SQLite-vec for relevant learnings with hierarchical scoping
   - `index-learnings`: Indexes all learning markdown files into SQLite-vec
   - `consolidate-discovery`: Finds consolidation candidates
   - `consolidate-actions`: Executes consolidation actions (merge, archive, delete)
 
 - **Hooks:**
+  - `SessionStart`: Initializes environment and dependencies
+  - `SessionEnd`: Extracts learnings asynchronously after response completion
+  - `UserPromptSubmit`: Runs auto-peek retrieval before Claude answers
   - `PreCompact`: Auto-extracts learnings before context compaction
-  - `Stop`: Auto-extracts learnings when Claude finishes responding
 
 ### Learning Scopes
 
 1. **Global** (`~/.projects/learnings/`): Security patterns, general best practices, cross-project knowledge
 2. **Repo** (`[repo]/.projects/learnings/`): Repository-specific gotchas, patterns, architecture decisions
 
-The search skill automatically detects which repository you're working in and includes both global and repo-scoped learnings.
+The search pipeline in `scripts/search-learnings.py` detects repository scope automatically and includes both global and repo-scoped learnings.
 
 ## Recommended CLAUDE.md Configuration
 
@@ -282,7 +288,7 @@ Add this to your global `~/.claude/CLAUDE.md`:
 **When to search:** If manifest shows a topic matching your task, search for it.
 **When to skip:** If no relevant topic in manifest, don't search.
 
-**Search:** `Skill(skill="compound-learning:search-learnings", args="[topic] [context]")`
+**Search:** `python3 plugins/compound-learning/scripts/search-learnings.py "[topic] [context]" "$PWD"`
 **Peek:** Add `--peek --exclude-ids [seen-ids]` when shifting to a new manifest topic mid-conversation.
 
 Use topic + context: "authentication JWT refresh" not "implement login feature"

--- a/plugins/compound-learning/scripts/check-doc-drift.py
+++ b/plugins/compound-learning/scripts/check-doc-drift.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Detect doc drift between compound-learning README and plugin files."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Dict, Iterable, List, Set, Tuple
+
+PLUGIN_RELATIVE_PREFIX = "plugins/compound-learning/"
+IGNORED_REFERENCE_PREFIXES = ("~", "/", "http://", "https://", "${", "$HOME", "[repo]/", ".claude/")
+
+
+def _sorted(values: Iterable[str]) -> List[str]:
+    return sorted(set(values))
+
+
+def discover_commands(plugin_root: Path) -> Set[str]:
+    commands_dir = plugin_root / "commands"
+    if not commands_dir.exists():
+        return set()
+    return {path.stem for path in commands_dir.glob("*.md") if path.is_file()}
+
+
+def discover_agents(plugin_root: Path) -> Set[str]:
+    agents_dir = plugin_root / "agents"
+    if not agents_dir.exists():
+        return set()
+    return {path.stem for path in agents_dir.glob("*.md") if path.is_file()}
+
+
+def discover_skills(plugin_root: Path) -> Set[str]:
+    skills_dir = plugin_root / "skills"
+    if not skills_dir.exists():
+        return set()
+
+    discovered: Set[str] = set()
+    for skill_dir in skills_dir.iterdir():
+        if skill_dir.is_dir() and (skill_dir / "SKILL.md").is_file():
+            discovered.add(skill_dir.name)
+    return discovered
+
+
+def discover_hook_events(plugin_root: Path) -> Tuple[Set[str], str | None]:
+    hooks_config = plugin_root / "hooks" / "hooks.json"
+    if not hooks_config.is_file():
+        return set(), None
+
+    try:
+        payload = json.loads(hooks_config.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        error = (
+            f"invalid JSON in hooks/hooks.json: {exc.msg} "
+            f"(line {exc.lineno}, column {exc.colno})"
+        )
+        return set(), error
+
+    if not isinstance(payload, dict):
+        return set(), "invalid hooks/hooks.json: top-level value must be an object"
+
+    hooks = payload.get("hooks", {})
+    if not isinstance(hooks, dict):
+        return set(), "invalid hooks/hooks.json: 'hooks' must be an object"
+    return set(hooks.keys()), None
+
+
+def extract_documented_components(readme_text: str) -> Dict[str, Set[str]]:
+    documented = {
+        "commands": set(),
+        "agents": set(),
+        "skills": set(),
+        "hooks": set(),
+    }
+
+    section_markers = {
+        "- **Commands:**": "commands",
+        "- **Agents:**": "agents",
+        "- **Skills:**": "skills",
+        "- **Hooks:**": "hooks",
+    }
+
+    in_components = False
+    current_section: str | None = None
+    for raw_line in readme_text.splitlines():
+        stripped = raw_line.strip()
+        if stripped == "### Components":
+            in_components = True
+            current_section = None
+            continue
+        if not in_components:
+            continue
+        if stripped.startswith("### ") and stripped != "### Components":
+            break
+
+        if stripped in section_markers:
+            current_section = section_markers[stripped]
+            continue
+
+        if stripped.startswith("- **") and stripped.endswith("**:"):
+            current_section = None
+            continue
+
+        if current_section is None or not stripped.startswith("- "):
+            continue
+
+        if current_section == "commands":
+            matches = re.findall(r"`/([a-z0-9][a-z0-9-]*)`", stripped)
+            if not matches:
+                matches = re.findall(r"/([a-z0-9][a-z0-9-]*)", stripped)
+            documented["commands"].update(matches)
+            continue
+
+        if current_section in {"agents", "skills"}:
+            documented[current_section].update(
+                re.findall(r"`([a-z0-9][a-z0-9-]*)`", stripped)
+            )
+            continue
+
+        if current_section == "hooks":
+            code_matches = re.findall(r"`([A-Za-z][A-Za-z0-9_-]*)`", stripped)
+            bold_matches = re.findall(r"\*\*([A-Za-z][A-Za-z0-9_-]*)\*\*", stripped)
+            documented["hooks"].update(code_matches)
+            documented["hooks"].update(bold_matches)
+
+    return documented
+
+
+def extract_backticked_local_references(readme_text: str) -> List[str]:
+    references: Set[str] = set()
+
+    for raw_ref in re.findall(r"`([^`\n]+)`", readme_text):
+        ref = raw_ref.strip().rstrip(".,:;)")
+        if not ref or " " in ref:
+            continue
+
+        normalized = ref.replace("\\", "/")
+        if normalized.startswith("./"):
+            normalized = normalized[2:]
+
+        if normalized.endswith("/") or "/" not in normalized:
+            continue
+        if normalized.startswith(IGNORED_REFERENCE_PREFIXES):
+            continue
+        if "*" in normalized:
+            continue
+
+        references.add(normalized)
+
+    return _sorted(references)
+
+
+def resolve_local_reference(ref: str, plugin_root: Path, repo_root: Path) -> Path | None:
+    candidates: List[Path] = []
+
+    if ref.startswith(PLUGIN_RELATIVE_PREFIX):
+        candidates.append(repo_root / ref)
+        trimmed = ref[len(PLUGIN_RELATIVE_PREFIX) :]
+        candidates.append(plugin_root / trimmed)
+    else:
+        candidates.append(plugin_root / ref)
+
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def compare_component(
+    title: str,
+    documented: Set[str],
+    actual: Set[str],
+) -> List[str]:
+    lines: List[str] = []
+    documented_only = _sorted(documented - actual)
+    undocumented = _sorted(actual - documented)
+
+    if documented_only or undocumented:
+        lines.append(f"{title}:")
+    if documented_only:
+        lines.append(f"  documented but missing from filesystem: {', '.join(documented_only)}")
+    if undocumented:
+        lines.append(f"  present in filesystem but undocumented: {', '.join(undocumented)}")
+
+    return lines
+
+
+def run_check(plugin_root: Path, readme_path: Path) -> int:
+    if not readme_path.is_file():
+        print(f"README not found: {readme_path}")
+        return 1
+
+    readme_text = readme_path.read_text(encoding="utf-8")
+    documented = extract_documented_components(readme_text)
+    hook_events, hook_error = discover_hook_events(plugin_root)
+    actual = {
+        "commands": discover_commands(plugin_root),
+        "agents": discover_agents(plugin_root),
+        "skills": discover_skills(plugin_root),
+        "hooks": hook_events,
+    }
+
+    repo_root = plugin_root.parent.parent if plugin_root.parent.parent else plugin_root
+    missing_references: List[str] = []
+    for ref in extract_backticked_local_references(readme_text):
+        if resolve_local_reference(ref, plugin_root, repo_root) is None:
+            missing_references.append(ref)
+
+    report_lines: List[str] = []
+    report_lines.extend(compare_component("Commands", documented["commands"], actual["commands"]))
+    report_lines.extend(compare_component("Agents", documented["agents"], actual["agents"]))
+    report_lines.extend(compare_component("Skills", documented["skills"], actual["skills"]))
+    report_lines.extend(compare_component("Hook events", documented["hooks"], actual["hooks"]))
+    if hook_error:
+        report_lines.append("Hook configuration:")
+        report_lines.append(f"  {hook_error}")
+
+    if missing_references:
+        report_lines.append("Local file references:")
+        report_lines.append(
+            "  referenced in README but missing from filesystem: "
+            + ", ".join(_sorted(missing_references))
+        )
+
+    if report_lines:
+        print(f"Documentation drift detected for {readme_path}:")
+        for line in report_lines:
+            print(f"- {line}" if not line.startswith("  ") else line)
+        return 1
+
+    print(f"No documentation drift detected for {readme_path}")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Check README/component drift for compound-learning plugin.")
+    parser.add_argument(
+        "--plugin-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="Path to plugin root (defaults to this script's plugin directory).",
+    )
+    parser.add_argument(
+        "--readme",
+        type=Path,
+        default=None,
+        help="Optional explicit README path (defaults to <plugin-root>/README.md).",
+    )
+
+    args = parser.parse_args()
+    plugin_root = args.plugin_root.resolve()
+    readme_path = args.readme.resolve() if args.readme else (plugin_root / "README.md").resolve()
+    return run_check(plugin_root, readme_path)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/compound-learning/tests/test_doc_drift_consistency.py
+++ b/plugins/compound-learning/tests/test_doc_drift_consistency.py
@@ -1,0 +1,190 @@
+import json
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+PLUGIN_ROOT = Path(__file__).parent.parent
+SCRIPT_PATH = PLUGIN_ROOT / "scripts" / "check-doc-drift.py"
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(content).lstrip("\n"), encoding="utf-8")
+
+
+def _run_checker(plugin_root: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "--plugin-root", str(plugin_root)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _build_minimal_plugin(
+    plugin_root: Path,
+    readme_text: str,
+    *,
+    include_plugin_config: bool = True,
+) -> None:
+    _write(plugin_root / "README.md", readme_text)
+    _write(plugin_root / "commands" / "compound.md", "# command\n")
+    _write(plugin_root / "agents" / "learning-writer.md", "# agent\n")
+    _write(plugin_root / "skills" / "index-learnings" / "SKILL.md", "# skill\n")
+    _write(plugin_root / "scripts" / "search-learnings.py", "print('ok')\n")
+    if include_plugin_config:
+        _write(plugin_root / ".claude-plugin" / "config.json", "{}\n")
+    _write(
+        plugin_root / "hooks" / "hooks.json",
+        json.dumps({"hooks": {"SessionStart": []}}, indent=2) + "\n",
+    )
+
+
+def test_doc_drift_checker_baseline_passes():
+    proc = _run_checker(PLUGIN_ROOT)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "No documentation drift detected" in proc.stdout
+
+
+def test_doc_drift_checker_detects_component_mismatch(tmp_path):
+    plugin_root = tmp_path / "compound-learning"
+    _build_minimal_plugin(
+        plugin_root,
+        """
+        # Compound Learning Plugin
+
+        See `scripts/search-learnings.py`.
+
+        ## Architecture
+
+        ### Components
+
+        - **Commands:**
+          - `/ghost`: missing command
+
+        - **Agents:**
+          - `learning-writer`: writes learnings
+
+        - **Skills:**
+          - `index-learnings`: indexes learnings
+
+        - **Hooks:**
+          - `SessionStart`: setup
+        """,
+    )
+
+    proc = _run_checker(plugin_root)
+    output = proc.stdout + proc.stderr
+    assert proc.returncode != 0
+    assert "Commands:" in output
+    assert "ghost" in output
+    assert "compound" in output
+
+
+def test_doc_drift_checker_detects_missing_local_reference(tmp_path):
+    plugin_root = tmp_path / "compound-learning"
+    _build_minimal_plugin(
+        plugin_root,
+        """
+        # Compound Learning Plugin
+
+        Existing script: `scripts/search-learnings.py`
+        Missing script: `scripts/missing-script.py`
+        Missing config: `.claude-plugin/missing-config.json`
+
+        ## Architecture
+
+        ### Components
+
+        - **Commands:**
+          - `/compound`: extracts learnings
+
+        - **Agents:**
+          - `learning-writer`: writes learnings
+
+        - **Skills:**
+          - `index-learnings`: indexes learnings
+
+        - **Hooks:**
+          - `SessionStart`: setup
+        """,
+    )
+
+    proc = _run_checker(plugin_root)
+    output = proc.stdout + proc.stderr
+    assert proc.returncode != 0
+    assert "Local file references:" in output
+    assert ".claude-plugin/missing-config.json" in output
+    assert "scripts/missing-script.py" in output
+
+
+def test_doc_drift_checker_checks_dot_claude_plugin_references(tmp_path):
+    plugin_root = tmp_path / "compound-learning"
+    _build_minimal_plugin(
+        plugin_root,
+        """
+        # Compound Learning Plugin
+
+        Config path: `.claude-plugin/config.json`
+
+        ## Architecture
+
+        ### Components
+
+        - **Commands:**
+          - `/compound`: extracts learnings
+
+        - **Agents:**
+          - `learning-writer`: writes learnings
+
+        - **Skills:**
+          - `index-learnings`: indexes learnings
+
+        - **Hooks:**
+          - `SessionStart`: setup
+        """,
+        include_plugin_config=False,
+    )
+
+    proc = _run_checker(plugin_root)
+    output = proc.stdout + proc.stderr
+    assert proc.returncode != 0
+    assert "Local file references:" in output
+    assert ".claude-plugin/config.json" in output
+
+
+def test_doc_drift_checker_handles_malformed_hooks_json(tmp_path):
+    plugin_root = tmp_path / "compound-learning"
+    _build_minimal_plugin(
+        plugin_root,
+        """
+        # Compound Learning Plugin
+
+        Existing script: `scripts/search-learnings.py`
+
+        ## Architecture
+
+        ### Components
+
+        - **Commands:**
+          - `/compound`: extracts learnings
+
+        - **Agents:**
+          - `learning-writer`: writes learnings
+
+        - **Skills:**
+          - `index-learnings`: indexes learnings
+
+        - **Hooks:**
+          - `SessionStart`: setup
+        """,
+    )
+    _write(plugin_root / "hooks" / "hooks.json", "{\n  \"hooks\": {\n")
+
+    proc = _run_checker(plugin_root)
+    output = proc.stdout + proc.stderr
+    assert proc.returncode != 0
+    assert "Hook configuration:" in output
+    assert "invalid JSON in hooks/hooks.json" in output
+    assert "Traceback" not in output


### PR DESCRIPTION
## Summary
- add `plugins/compound-learning/scripts/check-doc-drift.py` to detect README drift for commands, agents, skills, hook events, and backticked local file references
- handle malformed `hooks/hooks.json` as a controlled drift report instead of throwing a traceback
- align `plugins/compound-learning/README.md` component/hook/search references with the current plugin layout
- add `plugins/compound-learning/tests/test_doc_drift_consistency.py` covering baseline pass, component mismatch, missing local references (including `.claude-plugin/...`), and malformed hooks JSON

## Verification
- `python3 plugins/compound-learning/scripts/check-doc-drift.py`
- `python3 -m pytest plugins/compound-learning/tests/test_doc_drift_consistency.py`
- `python3 -m pytest plugins/compound-learning/tests/test_doc_drift_consistency.py plugins/compound-learning/tests/test_privacy_policy_consistency.py plugins/compound-learning/tests/test_config_backward_compat.py`
