### PR TITLE
Add compound-learning test gap finder

### DIFF
--- a/plugins/compound-learning/README.md
+++ b/plugins/compound-learning/README.md
@@ -200,7 +200,7 @@ python3 scripts/find-test-gaps.py \
 ```
 
 Gap categories:
-- `untested`: file has 0% coverage or no test reference signal.
+- `untested`: file has 0% coverage, or has neither coverage data nor any test-reference signal.
 - `low_coverage`: file coverage is below the configured threshold (`--threshold`, default `60`).
 - `indirectly_tested`: file appears in subprocess/path invocation signals from tests, but has no measured line coverage.
 

--- a/plugins/compound-learning/scripts/find-test-gaps.py
+++ b/plugins/compound-learning/scripts/find-test-gaps.py
@@ -380,19 +380,20 @@ def _classify_gap(
             "Referenced via subprocess/path invocation, but no measured line coverage.",
         )
 
-    reasons: List[str] = []
     if coverage_pct == 0.0:
-        reasons.append("0% coverage")
-    if not has_test_reference:
-        reasons.append("no test reference")
-    if reasons:
-        return "untested", " and ".join(reasons).capitalize() + "."
+        reason = "0% coverage."
+        if has_test_reference:
+            reason = "0% coverage despite test references."
+        return "untested", reason
 
     if coverage_pct is not None and coverage_pct < threshold:
         return (
             "low_coverage",
             f"Coverage {coverage_pct:.1f}% is below the {threshold:.1f}% threshold.",
         )
+
+    if coverage_pct is None and not has_test_reference:
+        return "untested", "No test reference or coverage signal."
 
     return None, None
 

--- a/plugins/compound-learning/tests/test_find_test_gaps.py
+++ b/plugins/compound-learning/tests/test_find_test_gaps.py
@@ -121,6 +121,29 @@ def test_prioritization_is_deterministic(tmp_path):
     assert [gap["priority_rank"] for gap in report["gaps"]] == [1, 2, 3]
 
 
+def test_high_coverage_without_detected_reference_is_not_untested(tmp_path):
+    plugin_root = tmp_path / "compound-learning"
+
+    _write(plugin_root / "lib" / "well_covered.py", "def run_it():\n    return 7\n")
+    _write(plugin_root / "tests" / "test_placeholder.py", "def test_placeholder():\n    assert True\n")
+
+    coverage_path = _write_coverage(
+        plugin_root,
+        {
+            "lib/well_covered.py": 93.0,
+        },
+    )
+
+    report = mod.find_test_gaps(
+        plugin_root=plugin_root,
+        threshold=60.0,
+        coverage_json=coverage_path,
+    )
+    by_path = {gap["path"]: gap for gap in report["gaps"]}
+
+    assert "lib/well_covered.py" not in by_path
+
+
 def test_renderers_and_cli_json_output(tmp_path, capsys):
     plugin_root = tmp_path / "compound-learning"
     _write(plugin_root / "lib" / "only.py", "def only():\n    return 1\n")


### PR DESCRIPTION
## Summary
- add `plugins/compound-learning/scripts/find-test-gaps.py` to combine coverage JSON + test reference heuristics for scoped executable files
- add CLI options for `--plugin-root`, `--format`, `--threshold`, `--coverage-json`, `--tests-dir`, and optional output file writing
- add `plugins/compound-learning/tests/test_find_test_gaps.py` with focused classification/prioritization/renderer tests
- document usage and category interpretation in `plugins/compound-learning/README.md`
- fix classification bug so well-covered Python files are not mislabeled `untested` when heuristic reference detection misses them

## Baseline (plugin-root run)
- high-priority untested Python gaps include `hooks/extract-transcript-messages.py`, `lib/topic_mapping.py`, and `scripts/backfill-topics.py`
- additional untested shell hooks/libs are reported via missing reference/coverage signals
- low coverage items currently include `lib/git_utils.py`, `lib/db.py`, `scripts/detect-knowledge-silos.py`, and `scripts/search-learnings.py`

## Validation
- `pytest -q plugins/compound-learning/tests/test_find_test_gaps.py`
- `pytest -q tests` (from `plugins/compound-learning`)
- `pytest --cov=hooks --cov=lib --cov=scripts --cov=skills --cov-report=json:coverage.json -q tests` + `python3 scripts/find-test-gaps.py --plugin-root . --format text` (from `plugins/compound-learning`)
