### PR TITLE
chore: finish dead-code cleanup in compound-learning

### DIFF
--- a/plugins/compound-learning/tests/test_search_relevance.py
+++ b/plugins/compound-learning/tests/test_search_relevance.py
@@ -55,7 +55,6 @@ def tmp_db(tmp_path, _embedding_model):
     Isolated SQLite database in a temporary directory.
     Returns (config, conn) tuple. Caller is responsible for conn.close().
     """
-    _ = embedding_model
     db_path = str(tmp_path / "test-compound-learning.db")
     config = {
         "sqlite": {"dbPath": db_path},


### PR DESCRIPTION
## Summary
- remove unused `abs_path` fields and constructor arguments from `SourceModule` and `TestReference` in `plugins/compound-learning/scripts/test-gap-finder.py`
- keep the existing test-search-relevance fixture naming from the base branch and remove a stale assignment line introduced while porting dead-code changes

## Verification
- `ruff check . --select F401,F841`
- `vulture hooks lib scripts skills tests --min-confidence 80`
- `pytest tests/test_find_test_gaps.py tests/test_test_gap_finder.py tests/test_observability.py tests/test_search_relevance.py` (14 passed, 8 skipped)
