### PR TITLE
Optimize compound-learning SessionStart dependency bootstrap

### DIFF
--- a/plugins/compound-learning/README.md
+++ b/plugins/compound-learning/README.md
@@ -8,6 +8,7 @@ A learning compounding system for Claude Code that extracts and indexes knowledg
 - GitHub CLI (`gh`) - optional, required for `/pr-learnings`
 
 Python dependencies (`pysqlite3-binary`, `sqlite-vec`, `sentence-transformers`) are auto-installed on session start via the `SessionStart` hook.
+Runtime dependencies are declared in `requirements-runtime.txt` and consumed by `hooks/setup.sh`.
 
 ## Installation
 
@@ -23,12 +24,26 @@ Python dependencies (`pysqlite3-binary`, `sqlite-vec`, `sentence-transformers`) 
 1. Clone or download this plugin to your Claude plugins directory
 2. Python dependencies install automatically on first session start, or install manually:
 ```bash
-pip install pysqlite3-binary sqlite-vec sentence-transformers
+pip install -r requirements-runtime.txt
 ```
 
 ### Post-Installation
 
 Run `/index-learnings` to build the index. The SQLite database is created automatically and the embedding model (~80MB) downloads on first use.
+
+### SessionStart Dependency Bootstrap
+
+`hooks/setup.sh` uses a manifest-driven bootstrap flow:
+
+1. Parse `requirements-runtime.txt` and normalize requirement-to-import mappings
+2. Build a cache key from Python version + manifest checksum
+3. On cache hit, validate cached imports/origins and skip reinstall
+4. On cache miss/stale, install only missing requirements
+5. Write a refreshed cache stamp to `~/.claude/plugins/compound-learning/setup-cache/`
+
+Force refresh controls:
+- `LEARNINGS_SETUP_FORCE_REFRESH=true`: invalidate cache and reinstall manifest dependencies
+- `LEARNINGS_FORCE_SETUP_REFRESH=true`: legacy alias for force refresh
 
 ## Configuration
 
@@ -217,3 +232,11 @@ Use topic + context: "authentication JWT refresh" not "implement login feature"
 
 **Hook activity log:**
 - Hook activity is logged to `~/.claude/plugins/compound-learning/activity.log`
+
+**SessionStart dependency issues:**
+- Force a one-time reinstall: `LEARNINGS_SETUP_FORCE_REFRESH=true`
+- Legacy force-refresh alias also works: `LEARNINGS_FORCE_SETUP_REFRESH=true`
+- Clear cache stamps manually: `rm -f ~/.claude/plugins/compound-learning/setup-cache/setup-*.stamp.json`
+
+**Observability log:**
+- Structured events are logged to `~/.claude/plugins/compound-learning/observability.jsonl` when `LEARNINGS_OBS_ENABLED=true`

--- a/plugins/compound-learning/hooks/observability.sh
+++ b/plugins/compound-learning/hooks/observability.sh
@@ -1,0 +1,276 @@
+#!/bin/bash
+
+# Shared logging + structured observability helpers for compound-learning hooks.
+
+hook_now_ms() {
+  local ms
+  ms=$(date +%s%3N 2>/dev/null)
+  if [ -n "$ms" ]; then
+    echo "$ms"
+  else
+    python3 - <<'PY'
+import time
+print(int(time.time() * 1000))
+PY
+  fi
+}
+
+hook_iso_utc() {
+  date -u '+%Y-%m-%dT%H:%M:%SZ'
+}
+
+hook_normalize_level() {
+  case "${1:-info}" in
+    debug) echo "debug" ;;
+    info) echo "info" ;;
+    warning|warn) echo "warn" ;;
+    error) echo "error" ;;
+    *) echo "info" ;;
+  esac
+}
+
+hook_level_rank() {
+  case "$(hook_normalize_level "$1")" in
+    debug) echo 10 ;;
+    info) echo 20 ;;
+    warn) echo 30 ;;
+    error) echo 40 ;;
+    *) echo 20 ;;
+  esac
+}
+
+hook_expand_home() {
+  local raw="$1"
+  echo "${raw//\$\{HOME\}/$HOME}"
+}
+
+hook_make_correlation_id() {
+  if [ -n "${LEARNINGS_OBS_CORRELATION_ID:-}" ]; then
+    echo "${LEARNINGS_OBS_CORRELATION_ID}"
+    return
+  fi
+  if [ -f /proc/sys/kernel/random/uuid ]; then
+    tr -d '-' < /proc/sys/kernel/random/uuid
+    return
+  fi
+  python3 - <<'PY'
+import uuid
+print(uuid.uuid4().hex)
+PY
+}
+
+hook_set_session_context() {
+  local session_id="$1"
+  if [ -n "$session_id" ] && [ "$session_id" != "null" ]; then
+    export LEARNINGS_OBS_SESSION_ID="$session_id"
+  fi
+}
+
+hook_json_or_null() {
+  local raw="$1"
+  if [ -z "$raw" ]; then
+    echo "null"
+    return
+  fi
+  if echo "$raw" | jq -e . >/dev/null 2>&1; then
+    echo "$raw"
+  else
+    echo "null"
+  fi
+}
+
+hook_log_init() {
+  HOOK_NAME="${1:-unknown}"
+  HOOK_LOG_DIR="$HOME/.claude/plugins/compound-learning"
+  if ! mkdir -p "$HOOK_LOG_DIR" 2>/dev/null; then
+    HOOK_LOG_DIR="$HOME/.claude/plugins/compound-learning-logs"
+    if ! mkdir -p "$HOOK_LOG_DIR" 2>/dev/null; then
+      HOOK_LOG_DIR="/tmp/compound-learning-logs"
+      mkdir -p "$HOOK_LOG_DIR" 2>/dev/null || true
+    fi
+  fi
+  HOOK_ACTIVITY_LOG="$HOOK_LOG_DIR/activity.log"
+
+  local config_file=""
+  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
+    config_file="${CLAUDE_PLUGIN_ROOT}/.claude-plugin/config.json"
+  else
+    local hook_dir
+    hook_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    config_file="$(cd "$hook_dir/.." && pwd)/.claude-plugin/config.json"
+  fi
+
+  local cfg_enabled=""
+  local cfg_level=""
+  local cfg_log_path=""
+  if [ -f "$config_file" ] && command -v jq >/dev/null 2>&1; then
+    cfg_enabled=$(jq -r '.observability.enabled // empty' "$config_file" 2>/dev/null)
+    cfg_level=$(jq -r '.observability.level // empty' "$config_file" 2>/dev/null)
+    cfg_log_path=$(jq -r '.observability.logPath // empty' "$config_file" 2>/dev/null)
+  fi
+
+  local enabled_raw="${LEARNINGS_OBS_ENABLED:-$cfg_enabled}"
+  case "${enabled_raw,,}" in
+    1|true|yes|on) HOOK_OBS_ENABLED="1" ;;
+    0|false|no|off) HOOK_OBS_ENABLED="0" ;;
+    *) HOOK_OBS_ENABLED="0" ;;
+  esac
+
+  HOOK_OBS_LEVEL="$(hook_normalize_level "${LEARNINGS_OBS_LEVEL:-$cfg_level}")"
+
+  local log_path_raw="${LEARNINGS_OBS_LOG_PATH:-$cfg_log_path}"
+  if [ -z "$log_path_raw" ]; then
+    log_path_raw="$HOOK_LOG_DIR/observability.jsonl"
+  fi
+  HOOK_OBS_LOG_PATH="$(hook_expand_home "$log_path_raw")"
+
+  HOOK_CORRELATION_ID="$(hook_make_correlation_id)"
+  HOOK_START_MS="$(hook_now_ms)"
+
+  # Export observability context so child Python processes emit joinable events.
+  export LEARNINGS_OBS_ENABLED="${HOOK_OBS_ENABLED:-0}"
+  export LEARNINGS_OBS_LEVEL="${HOOK_OBS_LEVEL:-info}"
+  export LEARNINGS_OBS_LOG_PATH="${HOOK_OBS_LOG_PATH:-$HOOK_LOG_DIR/observability.jsonl}"
+  export LEARNINGS_OBS_CORRELATION_ID="${HOOK_CORRELATION_ID:-}"
+  hook_set_session_context "${CLAUDE_SESSION_ID:-${CLAUDE_SESSION:-}}"
+}
+
+hook_log_activity() {
+  local message="$1"
+  printf '[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$message" >> "$HOOK_ACTIVITY_LOG"
+}
+
+hook_obs_level_allows() {
+  local requested
+  local minimum
+  requested="$(hook_level_rank "$1")"
+  minimum="$(hook_level_rank "${HOOK_OBS_LEVEL:-info}")"
+  [ "$requested" -ge "$minimum" ]
+}
+
+hook_safe_append() {
+  local line="$1"
+  mkdir -p "$(dirname "$HOOK_OBS_LOG_PATH")" 2>/dev/null || return 0
+  if command -v flock >/dev/null 2>&1; then
+    {
+      flock -x 200
+      printf '%s\n' "$line" >> "$HOOK_OBS_LOG_PATH" 2>/dev/null
+    } 200>>"${HOOK_OBS_LOG_PATH}.lock"
+  else
+    printf '%s\n' "$line" >> "$HOOK_OBS_LOG_PATH" 2>/dev/null
+  fi
+}
+
+hook_obs_event() {
+  local level="$1"
+  local operation="$2"
+  local status="$3"
+  shift 3
+
+  [ "${HOOK_OBS_ENABLED:-0}" = "1" ] || return 0
+  hook_obs_level_allows "$level" || return 0
+  command -v jq >/dev/null 2>&1 || return 0
+
+  local message=""
+  local duration_ms=""
+  local session_id=""
+  local correlation_id="${HOOK_CORRELATION_ID:-}"
+  local counts_json="null"
+  local error_json="null"
+  local extra_json="null"
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --message)
+        message="$2"
+        shift 2
+        ;;
+      --duration-ms)
+        duration_ms="$2"
+        shift 2
+        ;;
+      --session-id)
+        session_id="$2"
+        shift 2
+        ;;
+      --correlation-id)
+        correlation_id="$2"
+        shift 2
+        ;;
+      --counts-json)
+        counts_json="$(hook_json_or_null "$2")"
+        shift 2
+        ;;
+      --error-json)
+        error_json="$(hook_json_or_null "$2")"
+        shift 2
+        ;;
+      --extra-json)
+        extra_json="$(hook_json_or_null "$2")"
+        shift 2
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+
+  local duration_json="null"
+  if [ -n "$duration_ms" ]; then
+    duration_json="$duration_ms"
+  fi
+
+  local event
+  event=$(jq -cn \
+    --arg timestamp "$(hook_iso_utc)" \
+    --arg level "$(hook_normalize_level "$level")" \
+    --arg component "hook" \
+    --arg hook "${HOOK_NAME:-unknown}" \
+    --arg operation "$operation" \
+    --arg status "$status" \
+    --arg message "$message" \
+    --arg session_id "$session_id" \
+    --arg correlation_id "$correlation_id" \
+    --argjson duration_ms "$duration_json" \
+    --argjson counts "$counts_json" \
+    --argjson error "$error_json" \
+    --argjson extra "$extra_json" \
+    '
+    {
+      timestamp: $timestamp,
+      level: $level,
+      component: $component,
+      hook: $hook,
+      operation: $operation,
+      status: $status
+    }
+    + (if $duration_ms == null then {} else {duration_ms: $duration_ms} end)
+    + (if ($message | length) == 0 then {} else {message: $message} end)
+    + (if ($session_id | length) == 0 then {} else {session_id: $session_id} end)
+    + (if ($correlation_id | length) == 0 then {} else {correlation_id: $correlation_id} end)
+    + (if $counts == null then {} else {counts: $counts} end)
+    + (if $error == null then {} else {error: $error} end)
+    + (if $extra == null then {} else $extra end)
+    ' 2>/dev/null)
+
+  [ -n "$event" ] || return 0
+  hook_safe_append "$event"
+}
+
+hook_elapsed_ms() {
+  local end_ms
+  end_ms="$(hook_now_ms)"
+  if [ -z "${HOOK_START_MS:-}" ]; then
+    echo "0"
+    return
+  fi
+  if ! [[ "$end_ms" =~ ^[0-9]+$ ]] || ! [[ "$HOOK_START_MS" =~ ^[0-9]+$ ]]; then
+    echo "0"
+    return
+  fi
+  local elapsed=$((end_ms - HOOK_START_MS))
+  if [ "$elapsed" -lt 0 ]; then
+    elapsed=0
+  fi
+  echo "$elapsed"
+}

--- a/plugins/compound-learning/hooks/setup.sh
+++ b/plugins/compound-learning/hooks/setup.sh
@@ -2,34 +2,608 @@
 
 # Auto-install Python dependencies for compound-learning plugin
 # Runs on SessionStart to ensure deps are ready before other hooks fire
-# Idempotent: skips pip if all packages already importable
+# Manifest-driven and cache-aware:
+# - Warm starts validate a dependency cache stamp and skip pip
+# - Cold starts install only missing requirements
+# - Stale cache entries self-heal by reinstalling missing requirements
 # Exits 0 always to avoid blocking session start
 
-LOG_DIR="$HOME/.claude/plugins/compound-learning"
-mkdir -p "$LOG_DIR"
-LOG_FILE="$LOG_DIR/activity.log"
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$HOOK_DIR/observability.sh" || exit 0
 
-log_activity() {
-  echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" >> "$LOG_FILE"
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$HOOK_DIR/.." && pwd)}"
+REQUIREMENTS_FILE="${LEARNINGS_SETUP_REQUIREMENTS_FILE:-$PLUGIN_ROOT/requirements-runtime.txt}"
+PYTHON_BIN="${LEARNINGS_SETUP_PYTHON_BIN:-python3}"
+PIP_BIN="${LEARNINGS_SETUP_PIP_BIN:-pip}"
+CACHE_DIR="${LEARNINGS_SETUP_CACHE_DIR:-$HOME/.claude/plugins/compound-learning/setup-cache}"
+
+hook_log_init "setup"
+SESSION_ID="${CLAUDE_SESSION_ID:-}"
+hook_set_session_context "$SESSION_ID"
+HOOK_OUTCOME="success"
+HOOK_OUTCOME_MESSAGE=""
+SETUP_TMP_DIR=""
+
+is_truthy() {
+  case "${1,,}" in
+    1|true|yes|on) return 0 ;;
+    *) return 1 ;;
+  esac
 }
 
-# Quick check: can we import all required packages?
-if python3 -c "
-import importlib.util, sys
-for pkg in ['pysqlite3', 'sqlite_vec', 'sentence_transformers']:
-    if importlib.util.find_spec(pkg) is None:
-        sys.exit(1)
-" 2>/dev/null; then
+setup_mktemp_dir() {
+  local dir
+  dir="$(mktemp -d 2>/dev/null)"
+  if [ -z "$dir" ]; then
+    dir="$(mktemp -d -t compound-learning-setup-XXXXXX 2>/dev/null)"
+  fi
+  echo "$dir"
+}
+
+emit_subprocess_exit_event() {
+  local command_name="$1"
+  local exit_code="$2"
+  local level="warn"
+  local status="failure"
+  if [ "$exit_code" -eq 0 ]; then
+    level="info"
+    status="success"
+  fi
+
+  hook_obs_event "$level" "subprocess_exit" "$status" \
+    --session-id "$SESSION_ID" \
+    --counts-json "{\"command\":\"$command_name\",\"exit_code\":$exit_code}"
+}
+
+run_manifest_parse() {
+  local output_file="$1"
+  "$PYTHON_BIN" - "$REQUIREMENTS_FILE" "$output_file" <<'PY'
+import hashlib
+import json
+import pathlib
+import re
+import sys
+
+requirements_path = pathlib.Path(sys.argv[1])
+output_path = pathlib.Path(sys.argv[2])
+
+if not requirements_path.exists():
+    raise SystemExit(f"missing requirements file: {requirements_path}")
+
+dependencies = []
+seen = set()
+for raw_line in requirements_path.read_text(encoding="utf-8").splitlines():
+    line = raw_line.strip()
+    if not line or line.startswith("#"):
+        continue
+    if "#" in line:
+        line = line.split("#", 1)[0].strip()
+    if not line:
+        continue
+
+    requirement = line
+    import_name = ""
+    if "|" in line:
+        requirement, import_name = line.split("|", 1)
+        requirement = requirement.strip()
+        import_name = import_name.strip()
+
+    if not requirement:
+        continue
+
+    requirement_base = re.split(r"[<>=!~;\[]", requirement, maxsplit=1)[0].strip()
+    requirement_base = requirement_base.split()[0].strip()
+    if not requirement_base:
+        continue
+
+    if not import_name:
+        import_name = requirement_base.lower().replace("-", "_").replace(".", "_")
+
+    dep_key = (requirement, import_name)
+    if dep_key in seen:
+        continue
+    seen.add(dep_key)
+    dependencies.append(
+        {
+            "requirement": requirement,
+            "requirement_base": requirement_base,
+            "import": import_name,
+        }
+    )
+
+if not dependencies:
+    raise SystemExit("requirements file has no valid dependencies")
+
+canonical_state = "\n".join(
+    f"{dep['requirement']}|{dep['import']}" for dep in dependencies
+) + "\n"
+manifest_sha = hashlib.sha256(canonical_state.encode("utf-8")).hexdigest()
+python_version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+
+state = {
+    "requirements_file": str(requirements_path.resolve()),
+    "manifest_sha": manifest_sha,
+    "python_version": python_version,
+    "dependency_count": len(dependencies),
+    "dependencies": dependencies,
+}
+output_path.write_text(json.dumps(state, sort_keys=True), encoding="utf-8")
+PY
+}
+
+run_import_probe() {
+  local deps_file="$1"
+  local output_file="$2"
+  local command_name="$3"
+  local validate_origin="$4"
+  local exit_code=0
+
+  if "$PYTHON_BIN" - "$deps_file" "$output_file" "$validate_origin" <<'PY'
+import importlib.util
+import json
+import pathlib
+import sys
+
+deps_path = pathlib.Path(sys.argv[1])
+out_path = pathlib.Path(sys.argv[2])
+validate_origin = sys.argv[3] == "1"
+
+dependencies = json.loads(deps_path.read_text(encoding="utf-8"))
+present = []
+missing = []
+stale = []
+
+for dep in dependencies:
+    requirement = dep.get("requirement", "").strip()
+    import_name = dep.get("import", "").strip()
+    expected_origin = dep.get("origin", "").strip()
+    if not requirement or not import_name:
+        continue
+
+    spec = importlib.util.find_spec(import_name)
+    if spec is None:
+        missing.append(
+            {
+                "requirement": requirement,
+                "import": import_name,
+                "reason": "missing_spec",
+            }
+        )
+        continue
+
+    if spec.origin and spec.origin != "namespace":
+        resolved_origin = spec.origin
+    elif spec.submodule_search_locations:
+        resolved_origin = next(iter(spec.submodule_search_locations), "")
+    else:
+        resolved_origin = "<built-in>"
+
+    if validate_origin and expected_origin and expected_origin != resolved_origin:
+        stale.append(
+            {
+                "requirement": requirement,
+                "import": import_name,
+                "expected_origin": expected_origin,
+                "origin": resolved_origin,
+            }
+        )
+        missing.append(
+            {
+                "requirement": requirement,
+                "import": import_name,
+                "reason": "origin_mismatch",
+                "expected_origin": expected_origin,
+                "origin": resolved_origin,
+            }
+        )
+        continue
+
+    present.append(
+        {
+            "requirement": requirement,
+            "import": import_name,
+            "origin": resolved_origin,
+        }
+    )
+
+result = {
+    "checked": len(dependencies),
+    "missing": missing,
+    "present": present,
+    "stale": stale,
+}
+out_path.write_text(json.dumps(result, sort_keys=True), encoding="utf-8")
+sys.exit(0 if not missing else 1)
+PY
+  then
+    exit_code=0
+  else
+    exit_code=$?
+  fi
+
+  emit_subprocess_exit_event "$command_name" "$exit_code"
+  return "$exit_code"
+}
+
+extract_manifest_metadata() {
+  local manifest_state_file="$1"
+  local deps_output_file="$2"
+  "$PYTHON_BIN" - "$manifest_state_file" "$deps_output_file" <<'PY'
+import json
+import pathlib
+import sys
+
+state_path = pathlib.Path(sys.argv[1])
+deps_path = pathlib.Path(sys.argv[2])
+state = json.loads(state_path.read_text(encoding="utf-8"))
+dependencies = state.get("dependencies", []) or []
+
+deps_path.write_text(
+    json.dumps(dependencies, sort_keys=True), encoding="utf-8"
+)
+
+print(state.get("manifest_sha", ""))
+print(state.get("python_version", ""))
+print(state.get("dependency_count", len(dependencies)))
+PY
+}
+
+write_dependencies_from_stamp() {
+  local stamp_file="$1"
+  local output_file="$2"
+  "$PYTHON_BIN" - "$stamp_file" "$output_file" <<'PY'
+import json
+import pathlib
+import sys
+
+stamp = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+dependencies = stamp.get("dependencies", [])
+if not dependencies:
+    raise SystemExit("stamp file has no dependencies")
+pathlib.Path(sys.argv[2]).write_text(
+    json.dumps(dependencies, sort_keys=True), encoding="utf-8"
+)
+PY
+}
+
+write_install_list_from_probe() {
+  local probe_file="$1"
+  local output_file="$2"
+  "$PYTHON_BIN" - "$probe_file" "$output_file" <<'PY'
+import json
+import pathlib
+import sys
+
+probe = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+requirements = []
+seen = set()
+for entry in probe.get("missing", []):
+    requirement = entry.get("requirement", "").strip()
+    if not requirement or requirement in seen:
+        continue
+    seen.add(requirement)
+    requirements.append(requirement)
+pathlib.Path(sys.argv[2]).write_text("\n".join(requirements), encoding="utf-8")
+PY
+}
+
+count_probe_missing() {
+  local probe_file="$1"
+  "$PYTHON_BIN" - "$probe_file" <<'PY'
+import json
+import pathlib
+import sys
+
+probe = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+print(len(probe.get("missing", [])))
+PY
+}
+
+write_install_list_from_manifest() {
+  local deps_file="$1"
+  local output_file="$2"
+  "$PYTHON_BIN" - "$deps_file" "$output_file" <<'PY'
+import json
+import pathlib
+import sys
+
+dependencies = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+requirements = []
+seen = set()
+for dep in dependencies:
+    requirement = dep.get("requirement", "").strip()
+    if not requirement or requirement in seen:
+        continue
+    seen.add(requirement)
+    requirements.append(requirement)
+pathlib.Path(sys.argv[2]).write_text("\n".join(requirements), encoding="utf-8")
+PY
+}
+
+write_cache_stamp() {
+  local manifest_state_file="$1"
+  local probe_file="$2"
+  local cache_key="$3"
+  local stamp_file="$4"
+  "$PYTHON_BIN" - "$manifest_state_file" "$probe_file" "$cache_key" "$stamp_file" <<'PY'
+import datetime
+import json
+import pathlib
+import sys
+
+manifest_state = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+probe = json.loads(pathlib.Path(sys.argv[2]).read_text(encoding="utf-8"))
+cache_key = sys.argv[3]
+stamp_path = pathlib.Path(sys.argv[4])
+
+present_by_key = {
+    (entry.get("requirement", ""), entry.get("import", "")): entry.get("origin", "")
+    for entry in probe.get("present", [])
+}
+
+dependencies = []
+for dep in manifest_state.get("dependencies", []):
+    requirement = dep.get("requirement", "")
+    import_name = dep.get("import", "")
+    origin = present_by_key.get((requirement, import_name), "")
+    if not requirement or not import_name:
+        continue
+    dependencies.append(
+        {
+            "requirement": requirement,
+            "import": import_name,
+            "origin": origin,
+        }
+    )
+
+stamp = {
+    "cache_key": cache_key,
+    "manifest_sha": manifest_state.get("manifest_sha"),
+    "python_version": manifest_state.get("python_version"),
+    "dependency_count": len(dependencies),
+    "generated_at": datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+    "dependencies": dependencies,
+}
+stamp_path.write_text(json.dumps(stamp, sort_keys=True), encoding="utf-8")
+PY
+}
+
+setup_hook_finalize() {
+  local duration_ms
+  duration_ms="$(hook_elapsed_ms)"
+  local level="info"
+  case "$HOOK_OUTCOME" in
+    success) level="info" ;;
+    skipped) level="info" ;;
+    error) level="error" ;;
+    *) level="warn" ;;
+  esac
+
+  hook_obs_event "$level" "hook_end" "$HOOK_OUTCOME" \
+    --duration-ms "$duration_ms" \
+    --session-id "$SESSION_ID" \
+    --message "$HOOK_OUTCOME_MESSAGE"
+
+  if [ -n "$SETUP_TMP_DIR" ] && [ -d "$SETUP_TMP_DIR" ]; then
+    rm -rf "$SETUP_TMP_DIR" 2>/dev/null || true
+  fi
+}
+trap setup_hook_finalize EXIT
+
+hook_obs_event "info" "hook_start" "start" --session-id "$SESSION_ID"
+hook_log_activity "[setup] Bootstrap started"
+
+if [ ! -f "$REQUIREMENTS_FILE" ]; then
+  hook_log_activity "[setup] Requirements file not found: $REQUIREMENTS_FILE"
+  hook_obs_event "error" "dependency_manifest" "failure" \
+    --session-id "$SESSION_ID" \
+    --message "requirements file not found"
+  HOOK_OUTCOME="error"
+  HOOK_OUTCOME_MESSAGE="Requirements file missing"
   exit 0
 fi
 
-log_activity "[setup] Missing Python dependencies, installing..."
+SETUP_TMP_DIR="$(setup_mktemp_dir)"
+if [ -z "$SETUP_TMP_DIR" ] || [ ! -d "$SETUP_TMP_DIR" ]; then
+  hook_log_activity "[setup] Failed to create temporary directory"
+  hook_obs_event "error" "dependency_bootstrap" "failure" \
+    --session-id "$SESSION_ID" \
+    --message "failed to create temp directory"
+  HOOK_OUTCOME="error"
+  HOOK_OUTCOME_MESSAGE="Failed to create temp directory"
+  exit 0
+fi
 
-# Install all required packages quietly
-if pip install --quiet pysqlite3-binary sqlite-vec sentence-transformers 2>>"$LOG_FILE"; then
-  log_activity "[setup] Python dependencies installed successfully"
+MANIFEST_STATE_FILE="$SETUP_TMP_DIR/manifest-state.json"
+MANIFEST_DEPS_FILE="$SETUP_TMP_DIR/manifest-dependencies.json"
+CACHE_PROBE_FILE="$SETUP_TMP_DIR/cache-probe.json"
+IMPORT_PROBE_FILE="$SETUP_TMP_DIR/import-probe.json"
+POST_INSTALL_PROBE_FILE="$SETUP_TMP_DIR/post-install-probe.json"
+INSTALL_LIST_FILE="$SETUP_TMP_DIR/install-requirements.txt"
+STAMP_DEPS_FILE="$SETUP_TMP_DIR/stamp-dependencies.json"
+
+if run_manifest_parse "$MANIFEST_STATE_FILE"; then
+  emit_subprocess_exit_event "python_manifest_parse" 0
 else
-  log_activity "[setup] pip install failed (exit $?), plugin may not work correctly"
+  parse_exit=$?
+  emit_subprocess_exit_event "python_manifest_parse" "$parse_exit"
+  hook_log_activity "[setup] Failed to parse dependency manifest (exit $parse_exit)"
+  hook_obs_event "error" "dependency_manifest" "failure" \
+    --session-id "$SESSION_ID" \
+    --message "failed to parse requirements manifest"
+  HOOK_OUTCOME="error"
+  HOOK_OUTCOME_MESSAGE="Dependency manifest parse failed (exit $parse_exit)"
+  exit 0
+fi
+
+readarray -t MANIFEST_META < <(extract_manifest_metadata "$MANIFEST_STATE_FILE" "$MANIFEST_DEPS_FILE")
+MANIFEST_SHA="${MANIFEST_META[0]:-}"
+PYTHON_VERSION="${MANIFEST_META[1]:-}"
+DEPENDENCY_COUNT="${MANIFEST_META[2]:-0}"
+
+if [ -z "$MANIFEST_SHA" ] || [ -z "$PYTHON_VERSION" ]; then
+  hook_log_activity "[setup] Missing manifest metadata after parse"
+  HOOK_OUTCOME="error"
+  HOOK_OUTCOME_MESSAGE="Manifest metadata incomplete"
+  exit 0
+fi
+
+mkdir -p "$CACHE_DIR" 2>/dev/null || true
+CACHE_KEY="${PYTHON_VERSION}_${MANIFEST_SHA}"
+CACHE_KEY="${CACHE_KEY//[^a-zA-Z0-9._-]/_}"
+STAMP_FILE="$CACHE_DIR/setup-${CACHE_KEY}.stamp.json"
+
+FORCE_REFRESH_VALUE="${LEARNINGS_SETUP_FORCE_REFRESH:-}"
+FORCE_REFRESH_SOURCE=""
+if [ -n "$FORCE_REFRESH_VALUE" ]; then
+  FORCE_REFRESH_SOURCE="LEARNINGS_SETUP_FORCE_REFRESH"
+else
+  FORCE_REFRESH_VALUE="${LEARNINGS_FORCE_SETUP_REFRESH:-}"
+  if [ -n "$FORCE_REFRESH_VALUE" ]; then
+    FORCE_REFRESH_SOURCE="LEARNINGS_FORCE_SETUP_REFRESH"
+  fi
+fi
+
+FORCE_REFRESH=0
+if is_truthy "${FORCE_REFRESH_VALUE:-}"; then
+  FORCE_REFRESH=1
+fi
+
+if [ "$FORCE_REFRESH" -eq 1 ]; then
+  hook_log_activity "[setup] Force refresh requested via $FORCE_REFRESH_SOURCE"
+  hook_obs_event "info" "dependency_cache" "refresh" \
+    --session-id "$SESSION_ID" \
+    --message "force refresh requested"
+  rm -f "$STAMP_FILE" 2>/dev/null || true
+  if ! write_install_list_from_manifest "$MANIFEST_DEPS_FILE" "$INSTALL_LIST_FILE"; then
+    hook_log_activity "[setup] Failed to build install list for force refresh"
+    HOOK_OUTCOME="error"
+    HOOK_OUTCOME_MESSAGE="Failed to build force refresh install list"
+    exit 0
+  fi
+fi
+
+if [ "$FORCE_REFRESH" -eq 0 ] && [ -f "$STAMP_FILE" ]; then
+  if write_dependencies_from_stamp "$STAMP_FILE" "$STAMP_DEPS_FILE"; then
+    if run_import_probe "$STAMP_DEPS_FILE" "$CACHE_PROBE_FILE" "python_cache_validate" 1; then
+      hook_obs_event "info" "dependency_cache" "hit" \
+        --session-id "$SESSION_ID" \
+        --counts-json "{\"dependency_count\":$DEPENDENCY_COUNT}"
+      HOOK_OUTCOME="skipped"
+      HOOK_OUTCOME_MESSAGE="Dependencies cache hit"
+      hook_obs_event "info" "skip_reason" "skipped" \
+        --session-id "$SESSION_ID" \
+        --message "dependency cache hit"
+      exit 0
+    fi
+
+    cache_missing_count="$(count_probe_missing "$CACHE_PROBE_FILE")"
+    hook_log_activity "[setup] Dependency cache stale; missing=$cache_missing_count"
+    hook_obs_event "warn" "dependency_cache" "stale" \
+      --session-id "$SESSION_ID" \
+      --counts-json "{\"missing_packages\":$cache_missing_count}"
+    rm -f "$STAMP_FILE" 2>/dev/null || true
+    if ! write_install_list_from_probe "$CACHE_PROBE_FILE" "$INSTALL_LIST_FILE"; then
+      hook_log_activity "[setup] Failed to derive install list from stale cache probe"
+      HOOK_OUTCOME="error"
+      HOOK_OUTCOME_MESSAGE="Failed to derive stale cache install list"
+      exit 0
+    fi
+  else
+    hook_log_activity "[setup] Dependency cache stamp unreadable, invalidating"
+    hook_obs_event "warn" "dependency_cache" "stale" \
+      --session-id "$SESSION_ID" \
+      --message "unreadable dependency cache stamp"
+    rm -f "$STAMP_FILE" 2>/dev/null || true
+  fi
+elif [ "$FORCE_REFRESH" -eq 0 ]; then
+  hook_obs_event "info" "dependency_cache" "miss" \
+    --session-id "$SESSION_ID" \
+    --counts-json "{\"dependency_count\":$DEPENDENCY_COUNT}"
+fi
+
+if [ ! -f "$INSTALL_LIST_FILE" ]; then
+  if run_import_probe "$MANIFEST_DEPS_FILE" "$IMPORT_PROBE_FILE" "python_import_check" 0; then
+    hook_obs_event "info" "dependency_check" "success" \
+      --session-id "$SESSION_ID" \
+      --counts-json "{\"checked_dependencies\":$DEPENDENCY_COUNT,\"missing_packages\":0}"
+    if write_cache_stamp "$MANIFEST_STATE_FILE" "$IMPORT_PROBE_FILE" "$CACHE_KEY" "$STAMP_FILE"; then
+      hook_obs_event "info" "dependency_cache" "updated" \
+        --session-id "$SESSION_ID" \
+        --counts-json "{\"dependency_count\":$DEPENDENCY_COUNT}"
+    else
+      hook_obs_event "warn" "dependency_cache" "write_failed" \
+        --session-id "$SESSION_ID" \
+        --message "failed to write dependency cache stamp"
+    fi
+    HOOK_OUTCOME="skipped"
+    HOOK_OUTCOME_MESSAGE="Dependencies already installed"
+    hook_obs_event "info" "skip_reason" "skipped" \
+      --session-id "$SESSION_ID" \
+      --message "dependencies already installed"
+    exit 0
+  fi
+
+  missing_count="$(count_probe_missing "$IMPORT_PROBE_FILE")"
+  hook_obs_event "info" "dependency_check" "missing" \
+    --session-id "$SESSION_ID" \
+    --counts-json "{\"checked_dependencies\":$DEPENDENCY_COUNT,\"missing_packages\":$missing_count}"
+  if ! write_install_list_from_probe "$IMPORT_PROBE_FILE" "$INSTALL_LIST_FILE"; then
+    hook_log_activity "[setup] Failed to derive install list from import probe"
+    HOOK_OUTCOME="error"
+    HOOK_OUTCOME_MESSAGE="Failed to derive install list"
+    exit 0
+  fi
+fi
+
+mapfile -t INSTALL_REQUIREMENTS < "$INSTALL_LIST_FILE"
+
+if [ "${#INSTALL_REQUIREMENTS[@]}" -eq 0 ]; then
+  hook_obs_event "info" "dependency_install" "skipped" \
+    --session-id "$SESSION_ID" \
+    --message "no missing requirements to install"
+  HOOK_OUTCOME="skipped"
+  HOOK_OUTCOME_MESSAGE="No dependency installation needed"
+  exit 0
+fi
+
+hook_log_activity "[setup] Installing ${#INSTALL_REQUIREMENTS[@]} requirements"
+if "$PIP_BIN" install --quiet "${INSTALL_REQUIREMENTS[@]}" 2>>"$HOOK_ACTIVITY_LOG"; then
+  emit_subprocess_exit_event "pip_install" 0
+  if run_import_probe "$MANIFEST_DEPS_FILE" "$POST_INSTALL_PROBE_FILE" "python_post_install_check" 0; then
+    if write_cache_stamp "$MANIFEST_STATE_FILE" "$POST_INSTALL_PROBE_FILE" "$CACHE_KEY" "$STAMP_FILE"; then
+      hook_obs_event "info" "dependency_cache" "updated" \
+        --session-id "$SESSION_ID" \
+        --counts-json "{\"dependency_count\":$DEPENDENCY_COUNT}"
+    else
+      hook_obs_event "warn" "dependency_cache" "write_failed" \
+        --session-id "$SESSION_ID" \
+        --message "failed to write dependency cache stamp"
+    fi
+    hook_log_activity "[setup] Python dependencies installed successfully"
+    hook_obs_event "info" "dependency_install" "success" \
+      --session-id "$SESSION_ID" \
+      --counts-json "{\"installed_packages\":${#INSTALL_REQUIREMENTS[@]}}"
+    HOOK_OUTCOME="success"
+    HOOK_OUTCOME_MESSAGE="Dependencies installed successfully"
+  else
+    post_check_exit=$?
+    hook_log_activity "[setup] Post-install dependency validation failed (exit $post_check_exit)"
+    hook_obs_event "error" "dependency_install" "failure" \
+      --session-id "$SESSION_ID" \
+      --message "post-install validation failed"
+    HOOK_OUTCOME="error"
+    HOOK_OUTCOME_MESSAGE="Post-install dependency validation failed (exit $post_check_exit)"
+  fi
+else
+  pip_exit=$?
+  emit_subprocess_exit_event "pip_install" "$pip_exit"
+  hook_log_activity "[setup] pip install failed (exit $pip_exit), plugin may not work correctly"
+  hook_obs_event "error" "dependency_install" "failure" \
+    --session-id "$SESSION_ID" \
+    --counts-json "{\"attempted_packages\":${#INSTALL_REQUIREMENTS[@]}}"
+  HOOK_OUTCOME="error"
+  HOOK_OUTCOME_MESSAGE="pip install failed (exit $pip_exit)"
 fi
 
 exit 0

--- a/plugins/compound-learning/requirements-runtime.txt
+++ b/plugins/compound-learning/requirements-runtime.txt
@@ -1,0 +1,5 @@
+# Runtime dependency manifest for hooks/setup.sh
+# Format: requirement-spec|import-name (import-name is optional)
+pysqlite3-binary|pysqlite3
+sqlite-vec|sqlite_vec
+sentence-transformers|sentence_transformers

--- a/plugins/compound-learning/tests/test_setup_hook_cache.py
+++ b/plugins/compound-learning/tests/test_setup_hook_cache.py
@@ -1,0 +1,263 @@
+import json
+import os
+import shutil
+import stat
+import subprocess
+import textwrap
+from pathlib import Path
+
+PLUGIN_ROOT = Path(__file__).parent.parent
+SETUP_SCRIPT = PLUGIN_ROOT / "hooks" / "setup.sh"
+OBSERVABILITY_SCRIPT = PLUGIN_ROOT / "hooks" / "observability.sh"
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(content).lstrip("\n"), encoding="utf-8")
+
+
+def _write_fake_pip(path: Path) -> None:
+    _write(
+        path,
+        """
+        #!/usr/bin/env python3
+        import json
+        import os
+        import pathlib
+        import re
+        import sys
+
+        log_path = os.environ.get("FAKE_PIP_LOG")
+        install_map = json.loads(os.environ.get("FAKE_PIP_IMPORT_MAP_JSON", "{}"))
+        fail_for = {
+            token.strip()
+            for token in os.environ.get("FAKE_PIP_FAIL_FOR", "").split(",")
+            if token.strip()
+        }
+
+        def normalize_requirement(req: str) -> str:
+            return re.split(r"[<>=!~;\\[]", req, maxsplit=1)[0].strip()
+
+        argv = sys.argv[1:]
+        if not argv or argv[0] != "install":
+            sys.exit(0)
+
+        requested = [arg for arg in argv[1:] if not arg.startswith("-")]
+        requirements = []
+        for raw in requested:
+            normalized = normalize_requirement(raw)
+            if normalized:
+                requirements.append(normalized)
+
+        if log_path:
+            with open(log_path, "a", encoding="utf-8") as handle:
+                handle.write(json.dumps({"requirements": requirements}) + "\\n")
+
+        if fail_for.intersection(requirements):
+            sys.exit(2)
+
+        site_packages = pathlib.Path(os.environ["FAKE_SITE_PACKAGES"])
+        site_packages.mkdir(parents=True, exist_ok=True)
+
+        for requirement in requirements:
+            import_name = install_map.get(requirement, requirement.replace("-", "_").replace(".", "_"))
+            package_dir = site_packages / import_name
+            package_dir.mkdir(parents=True, exist_ok=True)
+            (package_dir / "__init__.py").write_text(
+                f"# generated for {requirement}\\n", encoding="utf-8"
+            )
+
+        sys.exit(0)
+        """,
+    )
+    path.chmod(path.stat().st_mode | stat.S_IEXEC)
+
+
+def _prepare_plugin_copy(tmp_path: Path, requirements_runtime: str) -> Path:
+    plugin_dir = tmp_path / "compound-learning"
+    hooks_dir = plugin_dir / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+
+    shutil.copy2(SETUP_SCRIPT, hooks_dir / "setup.sh")
+    shutil.copy2(OBSERVABILITY_SCRIPT, hooks_dir / "observability.sh")
+    _write(plugin_dir / "requirements-runtime.txt", requirements_runtime)
+
+    return plugin_dir
+
+
+def _build_env(tmp_path: Path, plugin_dir: Path, import_map: dict[str, str]) -> tuple[dict[str, str], Path, Path, Path]:
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir(parents=True, exist_ok=True)
+    fake_pip = fake_bin / "pip"
+    _write_fake_pip(fake_pip)
+
+    home_dir = tmp_path / "home"
+    home_dir.mkdir(parents=True, exist_ok=True)
+    site_packages = tmp_path / "site-packages"
+    site_packages.mkdir(parents=True, exist_ok=True)
+
+    obs_log = tmp_path / "observability.jsonl"
+    pip_log = tmp_path / "pip.log"
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": str(home_dir),
+            "CLAUDE_PLUGIN_ROOT": str(plugin_dir),
+            "LEARNINGS_OBS_ENABLED": "true",
+            "LEARNINGS_OBS_LEVEL": "debug",
+            "LEARNINGS_OBS_LOG_PATH": str(obs_log),
+            "PYTHONPATH": str(site_packages),
+            "PATH": f"{fake_bin}:{env.get('PATH', '')}",
+            "FAKE_SITE_PACKAGES": str(site_packages),
+            "FAKE_PIP_LOG": str(pip_log),
+            "FAKE_PIP_IMPORT_MAP_JSON": json.dumps(import_map),
+        }
+    )
+    return env, obs_log, pip_log, site_packages
+
+
+def _run_setup(plugin_dir: Path, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    proc = subprocess.run(
+        ["bash", str(plugin_dir / "hooks" / "setup.sh")],
+        cwd=plugin_dir,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return proc
+
+
+def _read_pip_log(pip_log: Path) -> list[list[str]]:
+    if not pip_log.exists():
+        return []
+    entries = []
+    for line in pip_log.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        payload = json.loads(line)
+        entries.append(payload.get("requirements", []))
+    return entries
+
+
+def _read_obs_events(obs_log: Path) -> list[dict]:
+    if not obs_log.exists():
+        return []
+    events = []
+    for line in obs_log.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        events.append(json.loads(line))
+    return events
+
+
+def _find_subprocess_exit(events: list[dict], command: str, exit_code: int) -> bool:
+    for event in events:
+        if event.get("operation") != "subprocess_exit":
+            continue
+        counts = event.get("counts") or {}
+        if counts.get("command") == command and counts.get("exit_code") == exit_code:
+            return True
+    return False
+
+
+def test_cache_hit_skips_reinstall(tmp_path):
+    plugin_dir = _prepare_plugin_copy(
+        tmp_path,
+        """
+        alpha-pkg
+        beta-pkg
+        """,
+    )
+    env, obs_log, pip_log, _site_packages = _build_env(tmp_path, plugin_dir, import_map={})
+
+    _run_setup(plugin_dir, env)
+    _run_setup(plugin_dir, env)
+
+    installs = _read_pip_log(pip_log)
+    assert installs == [["alpha-pkg", "beta-pkg"]]
+
+    events = _read_obs_events(obs_log)
+    assert any(e.get("operation") == "dependency_cache" and e.get("status") == "miss" for e in events)
+    assert any(e.get("operation") == "dependency_cache" and e.get("status") == "hit" for e in events)
+    assert _find_subprocess_exit(events, "python_cache_validate", 0)
+
+
+def test_manifest_checksum_change_installs_only_new_dependencies(tmp_path):
+    plugin_dir = _prepare_plugin_copy(
+        tmp_path,
+        """
+        alpha-pkg
+        """,
+    )
+    env, _obs_log, pip_log, _site_packages = _build_env(tmp_path, plugin_dir, import_map={})
+
+    _run_setup(plugin_dir, env)
+
+    _write(
+        plugin_dir / "requirements-runtime.txt",
+        """
+        alpha-pkg
+        beta-pkg
+        """,
+    )
+    _run_setup(plugin_dir, env)
+
+    installs = _read_pip_log(pip_log)
+    assert installs[0] == ["alpha-pkg"]
+    assert installs[1] == ["beta-pkg"]
+
+
+def test_stale_cache_recovers_missing_dependency(tmp_path):
+    plugin_dir = _prepare_plugin_copy(
+        tmp_path,
+        """
+        alpha-pkg
+        beta-pkg
+        """,
+    )
+    env, obs_log, pip_log, site_packages = _build_env(tmp_path, plugin_dir, import_map={})
+
+    _run_setup(plugin_dir, env)
+
+    shutil.rmtree(site_packages / "beta_pkg")
+
+    _run_setup(plugin_dir, env)
+
+    installs = _read_pip_log(pip_log)
+    assert installs == [["alpha-pkg", "beta-pkg"], ["beta-pkg"]]
+
+    events = _read_obs_events(obs_log)
+    assert any(e.get("operation") == "dependency_cache" and e.get("status") == "stale" for e in events)
+    assert _find_subprocess_exit(events, "python_cache_validate", 1)
+
+
+def test_observability_tracks_import_check_and_cache_paths(tmp_path):
+    plugin_dir = _prepare_plugin_copy(
+        tmp_path,
+        """
+        gamma-pkg|gamma_mod
+        """,
+    )
+    env, obs_log, _pip_log, _site_packages = _build_env(
+        tmp_path,
+        plugin_dir,
+        import_map={"gamma-pkg": "gamma_mod"},
+    )
+
+    _run_setup(plugin_dir, env)
+    _run_setup(plugin_dir, env)
+
+    events = _read_obs_events(obs_log)
+    assert _find_subprocess_exit(events, "python_import_check", 1)
+    assert _find_subprocess_exit(events, "pip_install", 0)
+    assert _find_subprocess_exit(events, "python_post_install_check", 0)
+    assert _find_subprocess_exit(events, "python_cache_validate", 0)
+
+    missing_events = [
+        e for e in events if e.get("operation") == "dependency_check" and e.get("status") == "missing"
+    ]
+    assert missing_events
+    assert missing_events[0].get("counts", {}).get("missing_packages") == 1


### PR DESCRIPTION
## Summary
This PR optimizes `plugins/compound-learning/hooks/setup.sh` SessionStart dependency bootstrap by making it manifest-driven, cache-aware, and self-healing:

- Added runtime manifest: `plugins/compound-learning/requirements-runtime.txt`
- Refactored setup bootstrap to:
  - Parse dependencies from manifest with requirement->import normalization
  - Compute deterministic cache key from Python version + manifest checksum
  - Use cache stamps for warm-start fast path
  - Install only missing requirements (selective installs)
  - Detect stale cache (missing imports/origin mismatch), invalidate stamp, and self-heal
  - Support force refresh controls:
    - `LEARNINGS_SETUP_FORCE_REFRESH=true`
    - legacy alias `LEARNINGS_FORCE_SETUP_REFRESH=true`
  - Preserve non-blocking behavior (`exit 0` on hook failure)
  - Emit observability events for cache hit/miss/stale/install/import-check outcomes
- Added shared hook observability helpers at `plugins/compound-learning/hooks/observability.sh`
- Added tests: `plugins/compound-learning/tests/test_setup_hook_cache.py`
  - cache-hit fast path
  - manifest checksum invalidation
  - stale-cache recovery
  - observability around import checks / cache checks
- Updated docs in `plugins/compound-learning/README.md`

## Timing Evidence
Measured in a fresh venv running `plugins/compound-learning/hooks/setup.sh` twice (cold then warm).

### Baseline (before)
- Cold: `223.66s`
- Warm: `0.07s`
- Behavior: fixed import probe + all-or-nothing install path

### After (this PR)
- Cold: `218.03s`
- Warm: `0.15s`
- Behavior: manifest parse + cache validation hit path; selective install/stale recovery path on miss

Notes:
- Warm path now includes explicit cache validation to enable stale-cache recovery; it remains sub-second and avoids pip on cache hits.
- Cold path remains dominated by first-time `sentence-transformers` dependency installation.

## Validation
Executed:

```bash
pytest plugins/compound-learning/tests/test_setup_hook_cache.py plugins/compound-learning/tests/test_find_test_gaps.py
```

Result: `7 passed`.

## Risk / Rollback
- Risk: setup hook behavior is more complex; cache/stamp metadata bugs could affect install decisions.
- Mitigation: e2e tests cover cache hit/miss/stale/observability paths; force-refresh env flag provides immediate manual recovery.
- Rollback: revert this PR to restore previous setup behavior.
