### PR TITLE
Improve logging audit coverage

### DIFF
--- a/plugins/compound-learning/hooks/extract-transcript-context.py
+++ b/plugins/compound-learning/hooks/extract-transcript-context.py
@@ -26,7 +26,11 @@ def extract_context(transcript_path: str, max_chars: int = 3000) -> str:
     try:
         with open(transcript_path, 'r') as f:
             lines = f.readlines()
-    except (FileNotFoundError, PermissionError):
+    except (FileNotFoundError, PermissionError) as exc:
+        print(
+            f"[extract-transcript-context] failed to read transcript {transcript_path}: {exc}",
+            file=sys.stderr,
+        )
         return ""
 
     # Parse lines in reverse to find content between last two user prompts

--- a/plugins/compound-learning/lib/git_utils.py
+++ b/plugins/compound-learning/lib/git_utils.py
@@ -8,6 +8,7 @@ In a worktree, .git is a file containing "gitdir: /path/to/main/.git/worktrees/n
 from __future__ import annotations
 
 import os
+import sys
 from pathlib import Path
 
 
@@ -77,7 +78,11 @@ def _read_gitdir(git_file: Path) -> str | None:
     """Read a .git worktree file and return the gitdir path, or None."""
     try:
         content = git_file.read_text().strip()
-    except OSError:
+    except OSError as exc:
+        print(
+            f"[git_utils] failed to read gitdir marker {git_file}: {exc}",
+            file=sys.stderr,
+        )
         return None
 
     if content.startswith("gitdir: "):

--- a/plugins/compound-learning/tests/test_extract_transcript_context.py
+++ b/plugins/compound-learning/tests/test_extract_transcript_context.py
@@ -1,0 +1,66 @@
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+PLUGIN_ROOT = Path(__file__).resolve().parent.parent
+MODULE_PATH = PLUGIN_ROOT / "hooks" / "extract-transcript-context.py"
+
+_spec = importlib.util.spec_from_file_location("extract_transcript_context", MODULE_PATH)
+mod = importlib.util.module_from_spec(_spec)
+sys.modules["extract_transcript_context"] = mod
+_spec.loader.exec_module(mod)
+
+
+def _write_transcript(path: Path, entries: list[dict]) -> None:
+    path.write_text(
+        "".join(f"{json.dumps(entry)}\n" for entry in entries),
+        encoding="utf-8",
+    )
+
+
+def test_extract_context_returns_recent_assistant_context_without_stderr(tmp_path, capsys):
+    transcript_path = tmp_path / "session.jsonl"
+    _write_transcript(
+        transcript_path,
+        [
+            {
+                "type": "user",
+                "message": {"content": "first prompt"},
+            },
+            {
+                "type": "assistant",
+                "message": {
+                    "content": [{"type": "text", "text": "first answer"}],
+                },
+            },
+            {
+                "type": "assistant",
+                "message": {
+                    "content": [{"type": "text", "text": "follow-up detail"}],
+                },
+            },
+            {
+                "type": "user",
+                "message": {"content": "latest prompt"},
+            },
+        ],
+    )
+
+    context = mod.extract_context(str(transcript_path))
+    captured = capsys.readouterr()
+
+    assert context == "first answer\nfollow-up detail"
+    assert captured.err == ""
+
+
+def test_extract_context_logs_transcript_read_failures_to_stderr(tmp_path, capsys):
+    missing_path = tmp_path / "missing.jsonl"
+
+    context = mod.extract_context(str(missing_path))
+    captured = capsys.readouterr()
+
+    assert context == ""
+    assert "[extract-transcript-context] failed to read transcript" in captured.err
+    assert str(missing_path) in captured.err
+

--- a/plugins/compound-learning/tests/test_git_utils.py
+++ b/plugins/compound-learning/tests/test_git_utils.py
@@ -1,0 +1,49 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+PLUGIN_ROOT = Path(__file__).resolve().parent.parent
+MODULE_PATH = PLUGIN_ROOT / "lib" / "git_utils.py"
+
+_spec = importlib.util.spec_from_file_location("git_utils", MODULE_PATH)
+mod = importlib.util.module_from_spec(_spec)
+sys.modules["git_utils"] = mod
+_spec.loader.exec_module(mod)
+
+
+def test_resolve_repo_root_reads_worktree_gitdir_without_stderr(tmp_path, capsys):
+    worktree_root = tmp_path / "worktree"
+    worktree_root.mkdir()
+    main_root = tmp_path / "main-repo"
+    gitdir = main_root / ".git" / "worktrees" / "feature"
+    (worktree_root / ".git").write_text(f"gitdir: {gitdir}\n", encoding="utf-8")
+
+    repo_root = mod.resolve_repo_root(str(worktree_root))
+    captured = capsys.readouterr()
+
+    assert repo_root == str(main_root)
+    assert captured.err == ""
+
+
+def test_resolve_repo_root_logs_unreadable_gitdir_marker(tmp_path, monkeypatch, capsys):
+    worktree_root = tmp_path / "worktree"
+    worktree_root.mkdir()
+    git_file = worktree_root / ".git"
+    git_file.write_text("gitdir: /tmp/main-repo/.git/worktrees/feature\n", encoding="utf-8")
+
+    original_read_text = Path.read_text
+
+    def fake_read_text(self, *args, **kwargs):
+        if self == git_file:
+            raise OSError("permission denied")
+        return original_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", fake_read_text)
+
+    repo_root = mod.resolve_repo_root(str(worktree_root))
+    captured = capsys.readouterr()
+
+    assert repo_root == str(worktree_root)
+    assert "[git_utils] failed to read gitdir marker" in captured.err
+    assert str(git_file) in captured.err
+

--- a/plugins/compound-learning/tests/test_logging_quality_auditor.py
+++ b/plugins/compound-learning/tests/test_logging_quality_auditor.py
@@ -231,6 +231,50 @@ def test_dynamic_f_string_context_is_not_low_context(tmp_path):
     assert not _findings_for_path(report, "scripts/dynamic-context.py")
 
 
+def test_contextual_stderr_diagnostics_clear_exception_handler_findings(tmp_path):
+    plugin_root = tmp_path / "compound-learning"
+
+    _write(
+        plugin_root / "hooks" / "contextual.py",
+        """
+        import sys
+
+        def extract_context(transcript_path: str):
+            try:
+                with open(transcript_path, "r", encoding="utf-8") as handle:
+                    return handle.read()
+            except (FileNotFoundError, PermissionError) as exc:
+                print(
+                    f"failed to read transcript {transcript_path}: {exc}",
+                    file=sys.stderr,
+                )
+                return ""
+        """,
+    )
+    _write(
+        plugin_root / "lib" / "gitdir.py",
+        """
+        import sys
+        from pathlib import Path
+
+        def read_gitdir(git_file: Path):
+            try:
+                return git_file.read_text().strip()
+            except OSError as exc:
+                print(
+                    f"failed to read gitdir marker {git_file}: {exc}",
+                    file=sys.stderr,
+                )
+                return None
+        """,
+    )
+
+    report = mod.audit_logging_quality(plugin_root)
+
+    assert not _findings_for_path(report, "hooks/contextual.py")
+    assert not _findings_for_path(report, "lib/gitdir.py")
+
+
 def test_conditional_reraise_still_flags_silent_branch(tmp_path):
     plugin_root = tmp_path / "compound-learning"
 


### PR DESCRIPTION
## Summary
- add contextual stderr diagnostics for transcript read failures and unreadable git worktree markers
- add focused module tests for success and failure-path logging behavior
- extend the logging auditor regression suite for contextual stderr exception handlers

## Audit
- before: 2 high-severity findings in hooks/extract-transcript-context.py and lib/git_utils.py
- after: 0 findings with `python3 plugins/compound-learning/scripts/logging-quality-auditor.py --plugin-root plugins/compound-learning --format json --fail-on high`

## Tests
- `pytest -q plugins/compound-learning/tests/test_logging_quality_auditor.py plugins/compound-learning/tests/test_extract_transcript_context.py plugins/compound-learning/tests/test_git_utils.py`
- `python3 plugins/compound-learning/scripts/logging-quality-auditor.py --plugin-root plugins/compound-learning --format json --fail-on high`