### PR TITLE
docs: backfill compound-learning maintainer docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,20 +12,21 @@ A marketplace of Claude Code plugins from Connsulting.
 
 ### compound-learning
 
-Learning compounding system that extracts knowledge from conversations and makes it searchable via ChromaDB vector database.
+Learning compounding system that extracts reusable knowledge from Claude sessions and PR feedback, indexes it locally in SQLite plus `sqlite-vec`, and surfaces relevant learnings automatically through Claude hooks.
 
 **Features:**
-- Automated learning extraction from conversations
-- ChromaDB-backed vector search
-- Hierarchical scope (global + repo-specific learnings)
-- Configurable via environment variables
+- `SessionStart` dependency bootstrap for Python search/indexing dependencies
+- `UserPromptSubmit` auto-peek with keyword extraction and hybrid SQLite search
+- `PreCompact` and `SessionEnd` extraction into global and repo-scoped learning files
+- Local SQLite, `sqlite-vec`, and FTS5 storage with no Docker requirement
+- Slash commands for compounding, PR learnings, indexing, and consolidation
 
 **Install:**
 ```
 /plugin install compound-learning@connsulting-plugins
 ```
 
-See [plugins/compound-learning/README.md](plugins/compound-learning/README.md) for setup and configuration.
+See [plugins/compound-learning/README.md](plugins/compound-learning/README.md) for setup, configuration, hook lifecycle, and maintainer docs.
 
 ## Development
 

--- a/plugins/compound-learning/.claude-plugin/config.json
+++ b/plugins/compound-learning/.claude-plugin/config.json
@@ -5,6 +5,35 @@
   "learnings": {
     "globalDir": "${HOME}/.projects/learnings",
     "repoSearchPath": "${HOME}",
-    "distanceThreshold": 0.5
+    "archiveDir": "${HOME}/.projects/archive/learnings",
+    "highConfidenceThreshold": 0.4,
+    "possiblyRelevantThreshold": 0.55,
+    "keywordBoostWeight": 0.65
+  },
+  "consolidation": {
+    "duplicateThreshold": 0.25,
+    "scopeKeywords": [
+      "security",
+      "authentication",
+      "jwt",
+      "oauth",
+      "encryption",
+      "password",
+      "token",
+      "api-key",
+      "secret",
+      "xss",
+      "sql-injection"
+    ],
+    "outdatedKeywords": [
+      "temporary",
+      "workaround",
+      "deprecated",
+      "todo",
+      "fixme",
+      "hack",
+      "remove later",
+      "obsolete"
+    ]
   }
 }

--- a/plugins/compound-learning/README.md
+++ b/plugins/compound-learning/README.md
@@ -1,13 +1,29 @@
 # Compound Learning Plugin
 
-A learning compounding system for Claude Code that extracts and indexes knowledge from conversations using local SQLite-vec semantic search. No Docker required.
+A learning compounding system for Claude Code that extracts reusable knowledge from conversations and PR feedback, stores it locally in SQLite plus `sqlite-vec`, and surfaces relevant learnings automatically through hooks. No Docker required.
 
-## Prerequisites
+## What It Includes
 
-- Python 3.x with pip
-- GitHub CLI (`gh`) - optional, required for `/pr-learnings`
+- Slash commands:
+  - `/compound` to write learnings from the current conversation
+  - `/pr-learnings` to extract learnings from GitHub PR feedback
+  - `/index-learnings` to rebuild the SQLite index and manifest
+  - `/consolidate-learnings` to find and clean up duplicate or outdated learnings
+- Hooks:
+  - `SessionStart` bootstraps Python dependencies
+  - `UserPromptSubmit` auto-peeks for relevant learnings
+  - `PreCompact` and `SessionEnd` extract new learnings asynchronously
+- Shared helpers for SQLite access, worktree-aware repo detection, and topic inference
 
-Python dependencies (`pysqlite3-binary`, `sqlite-vec`, `sentence-transformers`) are auto-installed on session start via the `SessionStart` hook.
+## Requirements
+
+- `python3` and `pip`
+- `jq`
+- `timeout` on `PATH`
+- `git`
+- `gh` on `PATH` if you want to use `/pr-learnings`
+
+Python dependencies (`pysqlite3-binary`, `sqlite-vec`, `sentence-transformers`) are auto-installed on `SessionStart` by [hooks/setup.sh](hooks/setup.sh). Shell tooling such as `jq` and `timeout` is not auto-installed.
 
 ## Installation
 
@@ -20,58 +36,67 @@ Python dependencies (`pysqlite3-binary`, `sqlite-vec`, `sentence-transformers`) 
 
 ### Manual Installation
 
-1. Clone or download this plugin to your Claude plugins directory
-2. Python dependencies install automatically on first session start, or install manually:
+1. Clone or copy this plugin into your Claude plugins directory.
+2. Start a Claude session once so the `SessionStart` hook can bootstrap Python dependencies.
+3. If you prefer to install them yourself, run:
+
 ```bash
 pip install pysqlite3-binary sqlite-vec sentence-transformers
 ```
 
 ### Post-Installation
 
-Run `/index-learnings` to build the index. The SQLite database is created automatically and the embedding model (~80MB) downloads on first use.
+Run `/index-learnings` after you have at least one learning file. The SQLite database is created automatically, and the embedding model downloads on first use.
 
 ## Configuration
 
-### Environment Variables
+Configuration loading order is:
+
+1. Environment variables
+2. [.claude-plugin/config.json](.claude-plugin/config.json)
+3. Built-in defaults from [lib/db.py](lib/db.py)
+
+### Environment Overrides
 
 | Variable | Description | Default |
 |----------|-------------|---------|
+| `SQLITE_DB_PATH` | SQLite database path | `~/.claude/compound-learning.db` |
 | `LEARNINGS_GLOBAL_DIR` | Global learnings directory | `~/.projects/learnings` |
 | `LEARNINGS_REPO_SEARCH_PATH` | Base path to search for repo learnings | `~` |
-| `LEARNINGS_DISTANCE_THRESHOLD` | Similarity threshold (0-1, lower = more similar) | `0.5` |
 
 **Example in `.claude/settings.json`:**
 ```json
 {
   "env": {
+    "SQLITE_DB_PATH": "/home/user/.claude/compound-learning.db",
     "LEARNINGS_GLOBAL_DIR": "/home/user/my-learnings",
     "LEARNINGS_REPO_SEARCH_PATH": "/home/user/projects"
   }
 }
 ```
 
-### Config File
+The older `LEARNINGS_DISTANCE_THRESHOLD` env var and `distanceThreshold` config key are stale on the current `main` branch and are not read by the search code.
 
-Create `.claude-plugin/config.json` in the plugin directory:
+### Config Keys
 
-```json
-{
-  "sqlite": {
-    "dbPath": "${HOME}/.claude/compound-learning.db"
-  },
-  "learnings": {
-    "globalDir": "${HOME}/.projects/learnings",
-    "repoSearchPath": "${HOME}",
-    "distanceThreshold": 0.5
-  }
-}
-```
+| Key | Used by | Default |
+|-----|---------|---------|
+| `sqlite.dbPath` | All SQLite readers and writers | `${HOME}/.claude/compound-learning.db` |
+| `learnings.globalDir` | Global learning storage and manifest generation | `${HOME}/.projects/learnings` |
+| `learnings.repoSearchPath` | Repo discovery for indexing and scoped search | `${HOME}` |
+| `learnings.archiveDir` | Consolidation backups and archive moves | `${HOME}/.projects/archive/learnings` |
+| `learnings.highConfidenceThreshold` | High-confidence search cutoff | `0.40` |
+| `learnings.possiblyRelevantThreshold` | Secondary search cutoff used for peek backfill | `0.55` |
+| `learnings.keywordBoostWeight` | Hybrid reranking weight for keyword overlap | `0.65` |
+| `consolidation.duplicateThreshold` | Duplicate detection cutoff | `0.25` |
+| `consolidation.scopeKeywords` | Keywords used when deciding scope-sensitive merges | Built-in list in [lib/db.py](lib/db.py) |
+| `consolidation.outdatedKeywords` | Markers used to flag stale learnings | Built-in list in [lib/db.py](lib/db.py) |
 
-`${HOME}` expands to your home directory.
+`${HOME}` expands to the user's home directory inside [.claude-plugin/config.json](.claude-plugin/config.json).
 
 ## Usage
 
-### Creating Learnings
+### Create Learnings
 
 After a productive session, use the `/compound` command:
 ```
@@ -81,38 +106,44 @@ Went poorly: [failures]
 Recommendations: [improvements]
 ```
 
-This extracts learnings and commits them to the appropriate scope:
-- **Global learnings** (`~/.projects/learnings/`): Applicable across all projects
-- **Repo learnings** (`[repo]/.projects/learnings/`): Specific to a repository
+The learning writer stores files in one of two scopes:
 
-### Extracting Learnings from PRs
+- Global learnings in `~/.projects/learnings/`
+- Repo-specific learnings in `[repo]/.projects/learnings/`
+
+### Extract Learnings From PRs
 
 ```
 /pr-learnings <PR-URL-or-number> [<PR-URL-or-number> ...]
 ```
 
-**Examples:**
-```bash
-/pr-learnings https://github.com/owner/repo/pull/123
-/pr-learnings 123 456 789
-```
+This command shells out to `gh`, fetches review threads plus code changes, and writes 0-3 learning files per PR. Run `/index-learnings` afterward to rebuild the index and manifest.
 
-Fetches PR data including reviews, comments, and code changes, then extracts 1-3 meaningful learnings per PR. Run `/index-learnings` afterward to make new learnings searchable.
-
-### Searching Learnings
-
-Learnings are automatically searched at the start of tasks. To manually search:
-```
-Skill(skill="search-learnings", args="JWT authentication patterns")
-```
-
-### Rebuilding the Index
+### Rebuild The Index
 
 ```
 /index-learnings
 ```
 
-Also generates a manifest at `~/.projects/learnings/MANIFEST.md` summarizing learnings by topic.
+The indexer scans global and repo learnings, upserts them into SQLite, prunes orphaned rows whose files were removed on disk, and regenerates `~/.projects/learnings/MANIFEST.md`.
+
+### Manual Search And Validation
+
+There is no packaged `search-learnings` skill on the current `main` branch. Auto-peek and manual validation both use [scripts/search-learnings.py](scripts/search-learnings.py):
+
+```bash
+PLUGIN_DIR=/path/to/compound-learning
+CLAUDE_PLUGIN_ROOT="$PLUGIN_DIR" \
+python3 "$PLUGIN_DIR/scripts/search-learnings.py" "jwt refresh token" "$PWD"
+```
+
+Useful flags:
+
+- `--peek` to return the compact auto-peek output shape
+- `--exclude-ids` to hide session-local duplicates
+- `--threshold` to override only the high-confidence cutoff
+- `--max-results` to bound output size
+- `--keywords-json` to search multiple extracted keywords in parallel
 
 ### Learnings Manifest
 
@@ -138,53 +169,47 @@ Generated: 2026-02-03T14:30:00Z
 
 Topics come from `**Topic:**` and `**Tags:**` fields in learning files. `**Type:** gotcha` learnings are flagged with ⚠️.
 
-### Auto-Extraction via Hooks
+## Hook Lifecycle
 
-The plugin automatically extracts learnings at key moments:
+| Event | Entrypoint | Async | Purpose |
+|-------|------------|-------|---------|
+| `SessionStart` | [hooks/setup.sh](hooks/setup.sh) | No | Import-checks and installs Python dependencies if needed |
+| `UserPromptSubmit` | [hooks/auto-peek.sh](hooks/auto-peek.sh) | No | Extracts 1-2 keywords and injects relevant learnings into context |
+| `PreCompact` | [hooks/extract-learnings.sh](hooks/extract-learnings.sh) | Yes | Extracts learnings before compaction drops context |
+| `SessionEnd` | [hooks/extract-learnings.sh](hooks/extract-learnings.sh) | Yes | Extracts learnings again at session end to catch late insights |
 
-- **PreCompact**: Before context compaction to preserve insights
-- **Stop**: When Claude finishes responding
+Important behavior:
 
-How it works:
-1. Hooks trigger `extract-learnings.sh` which invokes `claude -p` to analyze the transcript
-2. Claude reads the conversation transcript and identifies 0-3 meaningful learnings
-3. Learning files are written to the appropriate scope (global or repo)
-4. A session tracking file (`~/.claude/compound-processed-sessions`) prevents duplicate extraction
+- Auto-peek reads `prompt`, `transcript_path`, and `cwd` from hook stdin, calls `claude -p --model haiku` to extract keywords, and then calls [scripts/search-learnings.py](scripts/search-learnings.py) with `--peek`.
+- Auto-peek records seen result IDs in `~/.claude/plugins/compound-learning/sessions/*.seen` and prunes files older than 24 hours.
+- Extraction reads `session_id`, `transcript_path`, and `cwd`, skips transcripts shorter than 20 lines, and resolves worktree paths back to the main repo root before writing repo-scoped learnings.
+- Newly created learning files are indexed immediately by calling [skills/index-learnings/index-learnings.py](skills/index-learnings/index-learnings.py) with `--file`.
+- Both hook scripts that invoke `claude -p` set `CLAUDE_SUBPROCESS=1` and exit early if that variable is already present, which prevents hook recursion.
 
-**Debug log:** `~/.claude/compound-hook-debug.log`
+## Runtime Files And State
 
-**Note:** Extraction uses minimal permissions (`Read`, `Write`, `Bash(mkdir:*)`) and skips trivial sessions (<20 transcript lines).
+| Path | Purpose |
+|------|---------|
+| `~/.claude/compound-learning.db` | SQLite database containing `learnings`, `vec_learnings`, and `fts_learnings` |
+| `~/.claude/plugins/compound-learning/activity.log` | Shared hook activity log |
+| `~/.claude/plugins/compound-learning/sessions/*.seen` | Auto-peek dedupe state per transcript/session |
+| `~/.projects/learnings/` | Global learning files |
+| `[repo]/.projects/learnings/` | Repo-scoped learning files |
+| `~/.projects/archive/learnings/YYYY-MM-DD/` | Consolidation backups and archives |
+| `~/.projects/learnings/MANIFEST.md` | Topic summary generated by the indexer |
+| `~/.cache/huggingface/hub/models--sentence-transformers--all-MiniLM-L6-v2` | Default embedding model cache |
 
-## Architecture
+## Repository Layout
 
-### Components
+- `commands/*.md` contains the slash-command orchestration docs.
+- `agents/*.md` contains the writing and PR extraction agent prompts.
+- [hooks/README.md](hooks/README.md) documents hook triggers, stdin payloads, recursion guards, and troubleshooting.
+- [lib/README.md](lib/README.md) documents the shared Python and shell helper modules.
+- [scripts/README.md](scripts/README.md) documents the operator-facing search and topic-backfill scripts.
+- [skills/README.md](skills/README.md) indexes the packaged skills used for indexing and consolidation.
+- [tests/test_search_relevance.py](tests/test_search_relevance.py) contains the current SQLite search tests.
 
-- **Commands:**
-  - `/compound`: Extracts learnings from conversations and commits to appropriate scope
-  - `/pr-learnings`: Extracts learnings from GitHub PR reviews, comments, and code changes
-  - `/index-learnings`: Re-indexes all learning files into SQLite-vec
-  - `/consolidate-learnings`: Finds and merges duplicate or overlapping learnings
-
-- **Agents:**
-  - `learning-writer`: Analyzes conversations and extracts learnings
-  - `pr-learning-extractor`: Analyzes GitHub PRs and extracts learnings from reviews
-
-- **Skills:**
-  - `search-learnings`: Queries SQLite-vec for relevant learnings with hierarchical scoping
-  - `index-learnings`: Indexes all learning markdown files into SQLite-vec
-  - `consolidate-discovery`: Finds consolidation candidates
-  - `consolidate-actions`: Executes consolidation actions (merge, archive, delete)
-
-- **Hooks:**
-  - `PreCompact`: Auto-extracts learnings before context compaction
-  - `Stop`: Auto-extracts learnings when Claude finishes responding
-
-### Learning Scopes
-
-1. **Global** (`~/.projects/learnings/`): Security patterns, general best practices, cross-project knowledge
-2. **Repo** (`[repo]/.projects/learnings/`): Repository-specific gotchas, patterns, architecture decisions
-
-The search skill automatically detects which repository you're working in and includes both global and repo-scoped learnings.
+On the current `main` branch, dependency bootstrap still lives in [hooks/setup.sh](hooks/setup.sh); there is no shared `lib/bootstrap.py` module in this plugin yet.
 
 ## Recommended CLAUDE.md Configuration
 
@@ -198,7 +223,7 @@ Add this to your global `~/.claude/CLAUDE.md`:
 **When to search:** If manifest shows a topic matching your task, search for it.
 **When to skip:** If no relevant topic in manifest, don't search.
 
-**Search:** `Skill(skill="compound-learning:search-learnings", args="[topic] [context]")`
+**Search:** `python3 [plugin-path]/scripts/search-learnings.py "[topic] [context]" "$PWD"`
 **Peek:** Add `--peek --exclude-ids [seen-ids]` when shifting to a new manifest topic mid-conversation.
 
 Use topic + context: "authentication JWT refresh" not "implement login feature"
@@ -206,14 +231,7 @@ Use topic + context: "authentication JWT refresh" not "implement login feature"
 
 ## Troubleshooting
 
-**No learnings found:**
-- Verify learning files exist in configured paths
-- Run `/index-learnings` to re-index
-- Check config paths in `.claude-plugin/config.json`
-
-**Search returns no results:**
-- Check `distanceThreshold` setting (try increasing to 0.7)
-- Run `/index-learnings` to ensure learnings are indexed
-
-**Hook activity log:**
-- Hook activity is logged to `~/.claude/plugins/compound-learning/activity.log`
+- If hooks appear silent, inspect `~/.claude/plugins/compound-learning/activity.log` first.
+- If search returns nothing, run `/index-learnings`, confirm your files are under the configured learning directories, and then check `highConfidenceThreshold` / `possiblyRelevantThreshold` rather than the stale `distanceThreshold` key.
+- If `UserPromptSubmit` auto-peek fails immediately, verify that `jq`, `timeout`, `claude`, and `python3` are on `PATH`.
+- If `/pr-learnings` fails, confirm `gh --version` and `gh auth status`.

--- a/plugins/compound-learning/hooks/README.md
+++ b/plugins/compound-learning/hooks/README.md
@@ -1,0 +1,97 @@
+# Hooks
+
+This directory contains the Claude hook registration file plus the shell and Python entrypoints used at runtime.
+
+## Registered Events
+
+The plugin registers hooks in [hooks.json](hooks.json):
+
+| Event | Entrypoint | Async | Reads stdin | Purpose |
+|-------|------------|-------|-------------|---------|
+| `SessionStart` | [setup.sh](setup.sh) | No | No | Bootstrap Python dependencies |
+| `UserPromptSubmit` | [auto-peek.sh](auto-peek.sh) | No | Yes | Search for relevant learnings before Claude responds |
+| `PreCompact` | [extract-learnings.sh](extract-learnings.sh) | Yes | Yes | Extract learnings before transcript compaction |
+| `SessionEnd` | [extract-learnings.sh](extract-learnings.sh) | Yes | Yes | Extract learnings again at session end |
+
+Because `PreCompact` and `SessionEnd` are async in [hooks.json](hooks.json), extraction failures do not block the foreground Claude session. They are visible only through logs.
+
+## Shell Entrypoints
+
+### `setup.sh`
+
+- Trigger: `SessionStart`
+- Purpose: idempotent dependency bootstrap for `pysqlite3-binary`, `sqlite-vec`, and `sentence-transformers`
+- Behavior:
+  - Creates `~/.claude/plugins/compound-learning/activity.log`
+  - Runs a quick import check with `python3`
+  - Falls back to `pip install --quiet ...` if imports fail
+  - Always exits `0` so session start is never blocked
+
+### `auto-peek.sh`
+
+- Trigger: `UserPromptSubmit`
+- Expected stdin fields:
+  - `prompt`
+  - `transcript_path`
+  - `cwd`
+- Purpose: extract 1-2 search keywords with `claude -p --model haiku`, then call [../scripts/search-learnings.py](../scripts/search-learnings.py) in `--peek` mode
+- Behavior:
+  - Exits early if `CLAUDE_PLUGIN_ROOT` is unset
+  - Exits early if `CLAUDE_SUBPROCESS` is already set, which prevents nested hook recursion
+  - Skips short prompts under 10 characters
+  - Uses [extract-transcript-context.py](extract-transcript-context.py) to give Haiku recent assistant context
+  - Creates an empty temporary MCP config so keyword extraction avoids MCP/LSP startup cost
+  - Stores seen result IDs in `~/.claude/plugins/compound-learning/sessions/<transcript-id>.seen`
+  - Prunes `.seen` files older than 24 hours
+  - Writes a compact search summary plus the full matched learning content to stdout so Claude can use it immediately
+
+### `extract-learnings.sh`
+
+- Triggers: `PreCompact`, `SessionEnd`
+- Expected stdin fields:
+  - `session_id`
+  - `transcript_path`
+  - `cwd`
+- Purpose: extract 0-3 reusable learnings from the transcript, write markdown files, and index any newly created files
+- Behavior:
+  - Exits early if `CLAUDE_PLUGIN_ROOT` is unset
+  - Exits early if `CLAUDE_SUBPROCESS` is already set
+  - Sources [../lib/git-worktree.sh](../lib/git-worktree.sh) so worktree paths resolve back to the main repo root
+  - Skips transcripts shorter than 20 lines
+  - Uses [extract-transcript-messages.py](extract-transcript-messages.py) to strip tool noise from the JSONL transcript
+  - Invokes `claude -p --permission-mode bypassPermissions` with `Write` and `Bash(mkdir:*)` allowed
+  - Diffs the learning directories before and after the Claude subprocess to find newly created markdown files
+  - Re-indexes each new file with [../skills/index-learnings/index-learnings.py](../skills/index-learnings/index-learnings.py) `--file`
+
+## Python Helpers
+
+### `extract-transcript-context.py`
+
+- Used only by `auto-peek.sh`
+- Reads backward through the transcript and extracts assistant text between the last two real user prompts
+- Defaults to 3000 characters so the Haiku prompt stays small
+
+### `extract-transcript-messages.py`
+
+- Used only by `extract-learnings.sh`
+- Converts transcript JSONL into plain `[USER]` / `[ASSISTANT]` blocks
+- Removes tool calls, snapshots, meta entries, and most command/tool-result noise
+- Truncates from the end when the transcript exceeds the byte budget
+
+## Recursion And Safety
+
+- `auto-peek.sh` and `extract-learnings.sh` set `CLAUDE_SUBPROCESS=1` before calling `claude -p`.
+- Both scripts check for `CLAUDE_SUBPROCESS` at startup and bail immediately when it is already present.
+- `setup.sh` is intentionally non-fatal; dependency bootstrap failures are logged instead of breaking the session.
+- `extract-learnings.sh` writes only into `~/.projects/learnings` and `[repo]/.projects/learnings` by passing those directories explicitly via `--add-dir`.
+
+## Logs And Troubleshooting
+
+- Shared log file: `~/.claude/plugins/compound-learning/activity.log`
+- Typical failure sources:
+  - `jq` missing on `PATH`
+  - `timeout` missing on `PATH`
+  - `claude` unavailable for the nested subprocess calls
+  - malformed or missing `transcript_path` in hook stdin
+  - missing Python dependencies before `SessionStart` has completed once
+- If auto-peek prints `search failed`, inspect the activity log for the captured stderr from the keyword extraction or search subprocess.

--- a/plugins/compound-learning/lib/README.md
+++ b/plugins/compound-learning/lib/README.md
@@ -1,0 +1,83 @@
+# Library Modules
+
+This directory contains the shared Python and shell helpers used by the plugin runtime. Python entrypoints import `lib.*`, while shell hooks source [git-worktree.sh](git-worktree.sh).
+
+## Module Ownership
+
+| Module | Used by | Responsibility |
+|--------|---------|----------------|
+| [db.py](db.py) | `scripts/`, `skills/`, tests | Config loading, SQLite connection setup, sqlite-vec loading, embeddings, schema creation, CRUD helpers, and scoped search |
+| [git_utils.py](git_utils.py) | Python scripts and skills | Resolve worktree paths and repo names in Python |
+| [git-worktree.sh](git-worktree.sh) | Hook shell scripts | Resolve worktree paths and repo names in shell |
+| [topic_mapping.py](topic_mapping.py) | Indexer and topic backfill script | Infer `**Topic:**` values from `**Tags:**` |
+| [__init__.py](__init__.py) | Python import machinery | Marks `lib` as an importable package |
+
+There is no shared `bootstrap.py` module on the current `main` branch. Dependency bootstrap is still implemented directly in [../hooks/setup.sh](../hooks/setup.sh).
+
+## `db.py`
+
+`db.py` is the central runtime module.
+
+- Config precedence: environment variables -> [.claude-plugin/config.json](../.claude-plugin/config.json) -> built-in defaults
+- Environment overrides:
+  - `SQLITE_DB_PATH`
+  - `LEARNINGS_GLOBAL_DIR`
+  - `LEARNINGS_REPO_SEARCH_PATH`
+- Managed defaults:
+  - DB path: `~/.claude/compound-learning.db`
+  - Global learnings: `~/.projects/learnings`
+  - Archive: `~/.projects/archive/learnings`
+  - High-confidence threshold: `0.40`
+  - Possibly-relevant threshold: `0.55`
+  - Keyword boost weight: `0.65`
+  - Duplicate threshold: `0.25`
+- SQLite schema:
+  - `learnings`
+  - `vec_learnings`
+  - `fts_learnings`
+- Embeddings:
+  - Model: `sentence-transformers/all-MiniLM-L6-v2`
+  - Cache path: `~/.cache/huggingface/hub/models--sentence-transformers--all-MiniLM-L6-v2`
+
+Search behavior is intentionally hybrid:
+
+- Vector candidates come from `sqlite-vec`
+- FTS5 adds a small boost for exact keyword matches
+- Keyword overlap reduces adjusted distance further
+- Scope filtering always includes global learnings plus any detected repo scopes
+
+## Worktree Helpers
+
+The plugin keeps separate implementations for shell and Python:
+
+- [git_utils.py](git_utils.py) is imported by Python code such as [../scripts/search-learnings.py](../scripts/search-learnings.py) and [../skills/index-learnings/index-learnings.py](../skills/index-learnings/index-learnings.py).
+- [git-worktree.sh](git-worktree.sh) is sourced by [../hooks/extract-learnings.sh](../hooks/extract-learnings.sh).
+
+Both implementations do the same thing:
+
+- Walk upward until they find `.git`
+- Treat `.git` files as worktree markers
+- Convert `/path/to/repo/.git/worktrees/<name>` back to the main repository root
+- Fall back to the original directory when no repo is detected
+
+## Topic Mapping
+
+[topic_mapping.py](topic_mapping.py) provides a single `TOPIC_TAG_MAP` and `infer_topic_from_tags()` helper so the indexer and maintenance scripts infer topics consistently.
+
+Current callers:
+
+- [../skills/index-learnings/index-learnings.py](../skills/index-learnings/index-learnings.py)
+- [../scripts/backfill-topics.py](../scripts/backfill-topics.py)
+
+## Runtime Files And Directories
+
+The modules in this directory create or rely on these paths:
+
+| Path | Owner |
+|------|-------|
+| `~/.claude/compound-learning.db` | `db.get_connection()` |
+| `~/.claude/` | created implicitly when the DB directory is created |
+| `~/.cache/huggingface/...all-MiniLM-L6-v2` | `db.get_embedding()` |
+| `~/.projects/archive/learnings/` | configured in `db.load_config()`, used by consolidation actions |
+
+If you change config keys or defaults here, update [../README.md](../README.md) and [.claude-plugin/config.json](../.claude-plugin/config.json) in the same change.

--- a/plugins/compound-learning/scripts/README.md
+++ b/plugins/compound-learning/scripts/README.md
@@ -1,0 +1,86 @@
+# Scripts
+
+This directory holds operator-facing Python scripts. They are not packaged as slash commands themselves, but the hooks and skills call them directly.
+
+## `search-learnings.py`
+
+Purpose: search the SQLite index for relevant learnings with repo-aware scoping and hybrid reranking.
+
+Used by:
+
+- [../hooks/auto-peek.sh](../hooks/auto-peek.sh)
+- maintainers validating search behavior manually
+
+Basic usage:
+
+```bash
+PLUGIN_DIR=/path/to/compound-learning
+CLAUDE_PLUGIN_ROOT="$PLUGIN_DIR" \
+python3 "$PLUGIN_DIR/scripts/search-learnings.py" "prompt caching ttl" "$PWD"
+```
+
+Arguments and flags:
+
+| Option | Meaning |
+|--------|---------|
+| `query` | Search text; optional when `--keywords-json` is supplied |
+| `working_dir` | Directory used to detect repo scope |
+| `--peek` | Return the compact output format used by auto-peek |
+| `--exclude-ids` | Comma-separated IDs to omit from results |
+| `--threshold` | Override the high-confidence threshold only |
+| `--max-results` | Cap returned results |
+| `--keywords-json` | JSON array of keywords to search in parallel |
+
+Behavior:
+
+- Opens one SQLite connection per keyword query for thread safety
+- Detects the current repo hierarchy with [../lib/git_utils.py](../lib/git_utils.py)
+- Merges results across keywords, keeping the best distance per learning ID
+- Applies FTS5 and keyword-overlap boosts before splitting results into `high_confidence` and `possibly_relevant`
+- Emits JSON with statuses such as `success`, `found`, `empty`, `no_results`, or `error`
+
+Dependencies:
+
+- Indexed learnings already present in SQLite
+- Python packages from the `SessionStart` bootstrap
+
+## `backfill-topics.py`
+
+Purpose: add a missing `**Topic:**` field to existing learning files based on their `**Tags:**`.
+
+Used by:
+
+- maintainers cleaning older learning corpora before re-indexing
+
+Basic usage:
+
+```bash
+python3 backfill-topics.py --dry-run
+python3 backfill-topics.py --apply
+python3 backfill-topics.py --apply --dir /path/to/learnings
+```
+
+Arguments and flags:
+
+| Option | Meaning |
+|--------|---------|
+| `--dry-run` | Default mode; prints proposed changes without writing |
+| `--apply` | Writes `**Topic:**` lines into matching files |
+| `--dir PATH` | Directory to scan instead of `~/.projects/learnings` |
+
+Behavior:
+
+- Skips files that already contain `**Topic:**`
+- Skips `MANIFEST.md`
+- Uses [../lib/topic_mapping.py](../lib/topic_mapping.py) for inference
+- Inserts the topic after `**Type:**` when present, otherwise after the first heading
+
+Dependencies:
+
+- Standard library only
+- Markdown learning files with `**Tags:**` metadata
+
+## Relationship To The Index
+
+- `search-learnings.py` reads from the SQLite index and never touches markdown files directly.
+- `backfill-topics.py` updates markdown metadata only; run `/index-learnings` afterward if you want the SQLite index and manifest to reflect the new topics.

--- a/plugins/compound-learning/skills/README.md
+++ b/plugins/compound-learning/skills/README.md
@@ -1,0 +1,17 @@
+# Skills
+
+This directory contains the packaged skills that ship with the plugin on the current `main` branch.
+
+## Skill Index
+
+| Skill | Files | When It Is Used | Purpose |
+|-------|-------|-----------------|---------|
+| `index-learnings` | [index-learnings/SKILL.md](index-learnings/SKILL.md), [index-learnings/index-learnings.py](index-learnings/index-learnings.py) | `/index-learnings`, plus incremental indexing from [../hooks/extract-learnings.sh](../hooks/extract-learnings.sh) | Discover markdown learning files, upsert them into SQLite, prune orphaned rows, and regenerate `MANIFEST.md` |
+| `consolidate-discovery` | [consolidate-discovery/SKILL.md](consolidate-discovery/SKILL.md), [consolidate-discovery/consolidate-discovery.py](consolidate-discovery/consolidate-discovery.py) | Phase 1 of `/consolidate-learnings` | Find duplicate clusters and outdated candidates, returning compact JSON |
+| `consolidate-actions` | [consolidate-actions/SKILL.md](consolidate-actions/SKILL.md), [consolidate-actions/consolidate-actions.py](consolidate-actions/consolidate-actions.py) | Phase 3 of `/consolidate-learnings` or manual maintenance | Execute merge, archive, delete, rescope, and get actions with backups |
+
+## Notes
+
+- There is no `search-learnings` skill directory on the current `main` branch. Search is implemented as [../scripts/search-learnings.py](../scripts/search-learnings.py) and is called directly by [../hooks/auto-peek.sh](../hooks/auto-peek.sh).
+- Skill metadata lives in each subdirectory's `SKILL.md`; the Python entrypoint next to it performs the actual work.
+- If you add or remove skills here, update [../README.md](../README.md) so the top-level plugin docs stay aligned with the packaged surface area.


### PR DESCRIPTION
## Summary
- update the marketplace and plugin READMEs so they match the current SQLite/sqlite-vec implementation on `main`
- add missing maintainer READMEs for `hooks/`, `lib/`, `scripts/`, and `skills/`
- refresh the shipped plugin config example to match the keys the current code actually reads

## Scope Assumptions
- this backfill documents the current `main` branch implementation as-is rather than the separate in-progress bootstrap work
- on `main`, dependency bootstrap still lives in `hooks/setup.sh` and search is still exposed as `scripts/search-learnings.py`, so the docs explicitly call out that there is no `lib/bootstrap.py` or packaged `search-learnings` skill here yet

## Verification
- `pytest plugins/compound-learning/tests`
- `git diff --check`
- verified the new relative markdown links resolve
