### PR TITLE
fix(compound-learning): isolate runtime bootstrap state

### DIFF
--- a/plugins/compound-learning/README.md
+++ b/plugins/compound-learning/README.md
@@ -7,7 +7,7 @@ A learning compounding system for Claude Code that extracts and indexes knowledg
 - Python 3.x with pip
 - GitHub CLI (`gh`) - optional, required for `/pr-learnings`
 
-Python dependencies (`pysqlite3-binary`, `sqlite-vec`, `sentence-transformers`) are auto-installed on session start via the `SessionStart` hook.
+Core SQLite dependencies (`pysqlite3-binary`, `sqlite-vec`) are bootstrapped on session start. Embedding dependencies (`sentence-transformers`) install lazily on first semantic search or indexing use.
 
 ## Installation
 
@@ -21,14 +21,16 @@ Python dependencies (`pysqlite3-binary`, `sqlite-vec`, `sentence-transformers`) 
 ### Manual Installation
 
 1. Clone or download this plugin to your Claude plugins directory
-2. Python dependencies install automatically on first session start, or install manually:
+2. Core Python dependencies install automatically on first session start, or install manually:
 ```bash
-pip install pysqlite3-binary sqlite-vec sentence-transformers
+pip install --target ~/.claude/state/compound-learning/site-packages pysqlite3-binary sqlite-vec sentence-transformers
 ```
 
 ### Post-Installation
 
 Run `/index-learnings` to build the index. The SQLite database is created automatically and the embedding model (~80MB) downloads on first use.
+
+Runtime state now lives under `~/.claude/state/compound-learning/`. The plugin installation path under `~/.claude/plugins/compound-learning` is no longer used for logs, dependency state, or managed `site-packages`.
 
 ## Configuration
 
@@ -149,9 +151,9 @@ How it works:
 1. Hooks trigger `extract-learnings.sh` which invokes `claude -p` to analyze the transcript
 2. Claude reads the conversation transcript and identifies 0-3 meaningful learnings
 3. Learning files are written to the appropriate scope (global or repo)
-4. A session tracking file (`~/.claude/compound-processed-sessions`) prevents duplicate extraction
+4. Newly created files are indexed into SQLite when indexing dependencies are available
 
-**Debug log:** `~/.claude/compound-hook-debug.log`
+Semantic auto-peek stores session-scoped `.seen` files in `~/.claude/state/compound-learning/sessions/` to avoid repeating the same suggestions within a session.
 
 **Note:** Extraction uses minimal permissions (`Read`, `Write`, `Bash(mkdir:*)`) and skips trivial sessions (<20 transcript lines).
 
@@ -216,4 +218,7 @@ Use topic + context: "authentication JWT refresh" not "implement login feature"
 - Run `/index-learnings` to ensure learnings are indexed
 
 **Hook activity log:**
-- Hook activity is logged to `~/.claude/plugins/compound-learning/activity.log`
+- Hook activity is logged to `~/.claude/state/compound-learning/activity.log`
+
+**Bootstrap status:**
+- Dependency bootstrap status is stored in `~/.claude/state/compound-learning/bootstrap-status.json`

--- a/plugins/compound-learning/hooks/auto-peek.sh
+++ b/plugins/compound-learning/hooks/auto-peek.sh
@@ -10,9 +10,9 @@ if [ -z "$CLAUDE_PLUGIN_ROOT" ]; then
 fi
 
 # Setup logging
-LOG_DIR="$HOME/.claude/plugins/compound-learning"
-mkdir -p "$LOG_DIR"
-LOG_FILE="$LOG_DIR/activity.log"
+STATE_DIR="$HOME/.claude/state/compound-learning"
+mkdir -p "$STATE_DIR"
+LOG_FILE="$STATE_DIR/activity.log"
 
 log_activity() {
   echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" >> "$LOG_FILE"
@@ -37,11 +37,32 @@ if [ ${#PROMPT} -lt 10 ]; then
   exit 0
 fi
 
+# Keep prompt-submit fast: start heavy embedding bootstrap in the background
+# and skip semantic peek work until the dependency is ready.
+BOOTSTRAP_JSON=$(python3 "${CLAUDE_PLUGIN_ROOT}/lib/bootstrap.py" ensure embedding --background --json 2>/dev/null)
+BOOTSTRAP_STATE=$(echo "$BOOTSTRAP_JSON" | jq -r '.state // empty' 2>/dev/null)
+
+if [ "$BOOTSTRAP_STATE" = "started" ]; then
+  log_activity "[auto-peek] embedding bootstrap started in background; skipping semantic peek"
+  exit 0
+fi
+
+if [ "$BOOTSTRAP_STATE" = "installing" ]; then
+  log_activity "[auto-peek] embedding bootstrap still running; skipping semantic peek"
+  exit 0
+fi
+
+if [ "$BOOTSTRAP_STATE" = "failed" ] || [ -z "$BOOTSTRAP_STATE" ]; then
+  BOOTSTRAP_ERROR=$(echo "$BOOTSTRAP_JSON" | jq -r '.error // .message // "bootstrap status unavailable"' 2>/dev/null)
+  log_activity "[auto-peek] embedding bootstrap unavailable; skipping semantic peek: $BOOTSTRAP_ERROR"
+  exit 0
+fi
+
 # Expand ~ in transcript path
 TRANSCRIPT="${TRANSCRIPT/#\~/$HOME}"
 
 # Session-scoped deduplication via a plain-text state file.
-SESSIONS_DIR="$HOME/.claude/plugins/compound-learning/sessions"
+SESSIONS_DIR="$STATE_DIR/sessions"
 mkdir -p "$SESSIONS_DIR"
 
 # Prune session files older than 24 hours
@@ -144,7 +165,7 @@ rm -f "$ERR_FILE"
 
 # Check if we got results
 if [ $SEARCH_EXIT -ne 0 ]; then
-  echo "[auto-peek] search failed (check ~/.claude/plugins/compound-learning/activity.log)"
+  echo "[auto-peek] search failed (check ~/.claude/state/compound-learning/activity.log)"
   exit 0
 fi
 

--- a/plugins/compound-learning/hooks/extract-learnings.sh
+++ b/plugins/compound-learning/hooks/extract-learnings.sh
@@ -9,9 +9,9 @@ if [ -z "$CLAUDE_PLUGIN_ROOT" ]; then
 fi
 
 # Setup logging
-LOG_DIR="$HOME/.claude/plugins/compound-learning"
-mkdir -p "$LOG_DIR"
-LOG_FILE="$LOG_DIR/activity.log"
+STATE_DIR="$HOME/.claude/state/compound-learning"
+mkdir -p "$STATE_DIR"
+LOG_FILE="$STATE_DIR/activity.log"
 
 log_activity() {
   echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" >> "$LOG_FILE"

--- a/plugins/compound-learning/hooks/setup.sh
+++ b/plugins/compound-learning/hooks/setup.sh
@@ -1,35 +1,13 @@
 #!/bin/bash
 
-# Auto-install Python dependencies for compound-learning plugin
-# Runs on SessionStart to ensure deps are ready before other hooks fire
-# Idempotent: skips pip if all packages already importable
-# Exits 0 always to avoid blocking session start
+# Ensure lightweight SQLite dependencies on SessionStart.
+# Heavy embedding dependencies install lazily on first semantic use.
+# Exits 0 always to avoid blocking Claude session startup on bootstrap errors.
 
-LOG_DIR="$HOME/.claude/plugins/compound-learning"
-mkdir -p "$LOG_DIR"
-LOG_FILE="$LOG_DIR/activity.log"
-
-log_activity() {
-  echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" >> "$LOG_FILE"
-}
-
-# Quick check: can we import all required packages?
-if python3 -c "
-import importlib.util, sys
-for pkg in ['pysqlite3', 'sqlite_vec', 'sentence_transformers']:
-    if importlib.util.find_spec(pkg) is None:
-        sys.exit(1)
-" 2>/dev/null; then
-  exit 0
+if [ -z "$CLAUDE_PLUGIN_ROOT" ]; then
+  CLAUDE_PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 fi
 
-log_activity "[setup] Missing Python dependencies, installing..."
-
-# Install all required packages quietly
-if pip install --quiet pysqlite3-binary sqlite-vec sentence-transformers 2>>"$LOG_FILE"; then
-  log_activity "[setup] Python dependencies installed successfully"
-else
-  log_activity "[setup] pip install failed (exit $?), plugin may not work correctly"
-fi
+python3 "${CLAUDE_PLUGIN_ROOT}/lib/bootstrap.py" ensure core --quiet >/dev/null 2>&1 || true
 
 exit 0

--- a/plugins/compound-learning/lib/bootstrap.py
+++ b/plugins/compound-learning/lib/bootstrap.py
@@ -1,0 +1,742 @@
+#!/usr/bin/env python3
+"""
+Shared dependency bootstrap helpers for the compound-learning plugin.
+
+This module centralizes dependency detection, installation, and status/logging
+for both shell hooks and Python entry points.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import importlib.util
+import json
+import os
+import platform
+import shlex
+import shutil
+import sqlite3 as stdlib_sqlite3
+import subprocess
+import sys
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+CORE = "core"
+EMBEDDING = "embedding"
+
+STATE_READY = "ready"
+STATE_INSTALLING = "installing"
+STATE_FAILED = "failed"
+STATE_MISSING = "missing"
+
+DEFAULT_WAIT_TIMEOUT = 900
+
+
+class BootstrapError(RuntimeError):
+    """Raised when dependency bootstrap fails."""
+
+
+@dataclass
+class BootstrapResult:
+    dependency: str
+    state: str
+    changed: bool = False
+    message: str = ""
+    backend: str | None = None
+    pid: int | None = None
+    error: str | None = None
+    warning: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        data: dict[str, Any] = {
+            "dependency": self.dependency,
+            "state": self.state,
+            "changed": self.changed,
+            "message": self.message,
+        }
+        if self.backend:
+            data["backend"] = self.backend
+        if self.pid:
+            data["pid"] = self.pid
+        if self.error:
+            data["error"] = self.error
+        if self.warning:
+            data["warning"] = self.warning
+        return data
+
+
+def state_dir() -> Path:
+    return Path.home() / ".claude" / "state" / "compound-learning"
+
+
+def legacy_state_dir() -> Path:
+    return Path.home() / ".claude" / "plugins" / "compound-learning"
+
+
+def managed_site_dir() -> Path:
+    return state_dir() / "site-packages"
+
+
+def log_file() -> Path:
+    return state_dir() / "activity.log"
+
+
+def status_file() -> Path:
+    return state_dir() / "bootstrap-status.json"
+
+
+def lock_file() -> Path:
+    return state_dir() / "bootstrap-status.lock"
+
+
+def ensure_managed_site_dir_on_path() -> None:
+    site_dir = str(managed_site_dir())
+    if site_dir not in sys.path:
+        sys.path.insert(0, site_dir)
+
+
+def log_activity(message: str) -> None:
+    _ensure_directory(state_dir(), "Runtime state")
+    with open(log_file(), "a", encoding="utf-8") as handle:
+        handle.write(f"[{_timestamp()}] {message}\n")
+
+
+def ensure_core_dependencies(wait: bool = True) -> BootstrapResult:
+    return ensure_dependency(CORE, wait=wait, background=False)
+
+
+def ensure_embedding_dependencies(
+    wait: bool = True,
+    background: bool = False,
+) -> BootstrapResult:
+    return ensure_dependency(EMBEDDING, wait=wait, background=background)
+
+
+def prepare_embedding_for_auto_peek() -> BootstrapResult:
+    return ensure_embedding_dependencies(wait=False, background=True)
+
+
+def dependency_ready(dependency: str) -> bool:
+    ensure_managed_site_dir_on_path()
+    if dependency == CORE:
+        return _core_runtime_ready()
+    if dependency == EMBEDDING:
+        return _module_available("sentence_transformers")
+    raise ValueError(f"Unknown dependency group: {dependency}")
+
+
+def missing_packages(dependency: str) -> list[str]:
+    ensure_managed_site_dir_on_path()
+    if dependency == CORE:
+        packages: list[str] = []
+        if not _sqlite_runtime_ready():
+            packages.append(_pysqlite_package_name())
+        if not _module_available("sqlite_vec"):
+            packages.append("sqlite-vec")
+        return packages
+    if dependency == EMBEDDING:
+        return [] if _module_available("sentence_transformers") else ["sentence-transformers"]
+    raise ValueError(f"Unknown dependency group: {dependency}")
+
+
+def read_status() -> dict[str, Any]:
+    with _locked_status() as status:
+        return json.loads(json.dumps(status))
+
+
+def ensure_dependency(
+    dependency: str,
+    wait: bool = True,
+    background: bool = False,
+    timeout_seconds: int = DEFAULT_WAIT_TIMEOUT,
+) -> BootstrapResult:
+    ensure_managed_site_dir_on_path()
+
+    if dependency_ready(dependency):
+        with _locked_status() as status:
+            dep_state = status["dependencies"][dependency]
+            dep_state.update(
+                {
+                    "state": STATE_READY,
+                    "updated_at": _timestamp(),
+                    "finished_at": dep_state.get("finished_at") or _timestamp(),
+                    "pid": None,
+                    "error": None,
+                }
+            )
+            warning = status.get("legacy_path_warning")
+        return BootstrapResult(
+            dependency=dependency,
+            state=STATE_READY,
+            message=f"{dependency} dependencies are ready",
+            warning=warning,
+        )
+
+    wait_for_existing = False
+    warning: str | None = None
+    with _locked_status() as status:
+        dep_state = status["dependencies"][dependency]
+        warning = status.get("legacy_path_warning")
+
+        if dep_state["state"] == STATE_READY and dependency_ready(dependency):
+            return BootstrapResult(
+                dependency=dependency,
+                state=STATE_READY,
+                message=f"{dependency} dependencies are ready",
+                warning=warning,
+            )
+
+        owner_pid = dep_state.get("pid")
+        if dep_state["state"] == STATE_INSTALLING and owner_pid == os.getpid():
+            pass
+        elif dep_state["state"] == STATE_INSTALLING:
+            if background or not wait:
+                return BootstrapResult(
+                    dependency=dependency,
+                    state=STATE_INSTALLING,
+                    message=f"{dependency} dependency bootstrap is already running",
+                    pid=owner_pid,
+                    warning=warning,
+                )
+            wait_for_existing = True
+        elif background:
+            child_pid = _spawn_background_install(dependency)
+            dep_state.update(
+                {
+                    "state": STATE_INSTALLING,
+                    "updated_at": _timestamp(),
+                    "started_at": dep_state.get("started_at") or _timestamp(),
+                    "finished_at": None,
+                    "pid": child_pid,
+                    "error": None,
+                }
+            )
+            log_activity(
+                f"[bootstrap] Started background install for {dependency} dependencies (pid {child_pid})"
+            )
+            return BootstrapResult(
+                dependency=dependency,
+                state="started",
+                changed=True,
+                message=f"Started background install for {dependency} dependencies",
+                pid=child_pid,
+                warning=warning,
+            )
+        else:
+            dep_state.update(
+                {
+                    "state": STATE_INSTALLING,
+                    "updated_at": _timestamp(),
+                    "started_at": dep_state.get("started_at") or _timestamp(),
+                    "finished_at": None,
+                    "pid": os.getpid(),
+                    "error": None,
+                }
+            )
+
+    if wait_for_existing:
+        return _wait_for_dependency(dependency, timeout_seconds)
+
+    packages = missing_packages(dependency)
+    if not packages and dependency_ready(dependency):
+        return BootstrapResult(
+            dependency=dependency,
+            state=STATE_READY,
+            message=f"{dependency} dependencies are ready",
+            warning=warning,
+        )
+    if not packages:
+        error = _manual_install_message(
+            dependency,
+            "Automatic dependency detection found no installable packages for this missing runtime.",
+        )
+        _mark_failed(dependency, error)
+        raise BootstrapError(error)
+
+    backend: str | None = None
+    try:
+        backend = _install_packages(dependency, packages)
+        ensure_managed_site_dir_on_path()
+        if not dependency_ready(dependency):
+            raise BootstrapError(
+                _manual_install_message(
+                    dependency,
+                    f"{dependency} packages installed via {backend}, but the runtime is still unavailable.",
+                )
+            )
+    except BootstrapError as exc:
+        _mark_failed(dependency, str(exc))
+        log_activity(f"[bootstrap] Failed to install {dependency} dependencies: {exc}")
+        raise
+
+    with _locked_status() as status:
+        dep_state = status["dependencies"][dependency]
+        dep_state.update(
+            {
+                "state": STATE_READY,
+                "updated_at": _timestamp(),
+                "finished_at": _timestamp(),
+                "pid": None,
+                "error": None,
+            }
+        )
+        warning = status.get("legacy_path_warning")
+    log_activity(
+        f"[bootstrap] {dependency} dependencies are ready"
+        + (f" via {backend}" if backend else "")
+    )
+    return BootstrapResult(
+        dependency=dependency,
+        state=STATE_READY,
+        changed=True,
+        message=f"{dependency} dependencies are ready",
+        backend=backend,
+        warning=warning,
+    )
+
+
+def _wait_for_dependency(dependency: str, timeout_seconds: int) -> BootstrapResult:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        status = read_status()
+        dep_state = status["dependencies"][dependency]
+        warning = status.get("legacy_path_warning")
+        if dep_state["state"] == STATE_READY or dependency_ready(dependency):
+            return BootstrapResult(
+                dependency=dependency,
+                state=STATE_READY,
+                message=f"{dependency} dependencies are ready",
+                warning=warning,
+            )
+        if dep_state["state"] == STATE_FAILED:
+            error = dep_state.get("error") or _manual_install_message(
+                dependency,
+                f"{dependency} dependency bootstrap failed.",
+            )
+            raise BootstrapError(error)
+        time.sleep(1)
+
+    error = _manual_install_message(
+        dependency,
+        f"Timed out waiting for {dependency} dependency bootstrap to finish.",
+    )
+    _mark_failed(dependency, error)
+    raise BootstrapError(error)
+
+
+def _install_packages(dependency: str, packages: list[str]) -> str:
+    backend_name, install_cmd = _build_install_command(dependency, packages)
+    log_activity(
+        f"[bootstrap] Installing {dependency} dependencies via {backend_name}: {', '.join(packages)}"
+    )
+    _ensure_directory(state_dir(), "Runtime state")
+    with open(log_file(), "a", encoding="utf-8") as handle:
+        process = subprocess.run(
+            install_cmd,
+            stdout=handle,
+            stderr=handle,
+            check=False,
+        )
+    if process.returncode != 0:
+        raise BootstrapError(
+            _manual_install_message(
+                dependency,
+                f"{backend_name} exited with code {process.returncode} while installing {', '.join(packages)}.",
+                install_command=install_cmd,
+            )
+        )
+    return backend_name
+
+
+def _build_install_command(dependency: str, packages: list[str]) -> tuple[str, list[str]]:
+    target_dir = str(_ensure_directory(managed_site_dir(), "Managed site-packages"))
+    install_command = _available_install_command(target_dir, packages)
+    if install_command:
+        return install_command
+
+    raise BootstrapError(
+        _manual_install_message(
+            dependency,
+            "Neither pip nor uv is available for automatic dependency bootstrap.",
+        )
+    )
+
+
+def _spawn_background_install(dependency: str) -> int:
+    _ensure_directory(state_dir(), "Runtime state")
+    with open(log_file(), "a", encoding="utf-8") as handle:
+        process = subprocess.Popen(
+            [
+                sys.executable,
+                str(Path(__file__).resolve()),
+                "ensure",
+                dependency,
+                "--foreground",
+                "--quiet",
+            ],
+            stdout=handle,
+            stderr=handle,
+            start_new_session=True,
+            close_fds=True,
+        )
+    return process.pid
+
+
+def _mark_failed(dependency: str, error: str) -> None:
+    with _locked_status() as status:
+        dep_state = status["dependencies"][dependency]
+        dep_state.update(
+            {
+                "state": STATE_FAILED,
+                "updated_at": _timestamp(),
+                "finished_at": _timestamp(),
+                "pid": None,
+                "error": error,
+            }
+        )
+
+
+@contextmanager
+def _locked_status() -> Any:
+    _ensure_directory(state_dir(), "Runtime state")
+    with open(lock_file(), "a+", encoding="utf-8") as handle:
+        fcntl.flock(handle, fcntl.LOCK_EX)
+        status = _load_status_unlocked()
+        if _normalize_status_unlocked(status):
+            _write_status_unlocked(status)
+        try:
+            yield status
+        finally:
+            _write_status_unlocked(status)
+            fcntl.flock(handle, fcntl.LOCK_UN)
+
+
+def _load_status_unlocked() -> dict[str, Any]:
+    path = status_file()
+    if not path.exists():
+        return {"dependencies": _default_dependencies_status()}
+
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            status = json.load(handle)
+    except (OSError, json.JSONDecodeError):
+        status = {"dependencies": _default_dependencies_status()}
+
+    status.setdefault("dependencies", {})
+    for dependency, dep_state in _default_dependencies_status().items():
+        status["dependencies"].setdefault(dependency, dep_state)
+    return status
+
+
+def _write_status_unlocked(status: dict[str, Any]) -> None:
+    path = status_file()
+    _ensure_directory(path.parent, "Runtime state")
+    tmp_path = path.with_suffix(".tmp")
+    with open(tmp_path, "w", encoding="utf-8") as handle:
+        json.dump(status, handle, indent=2, sort_keys=True)
+    os.replace(tmp_path, path)
+
+
+def _default_dependencies_status() -> dict[str, dict[str, Any]]:
+    timestamp = _timestamp()
+    return {
+        CORE: {
+            "state": STATE_READY if dependency_ready(CORE) else STATE_MISSING,
+            "updated_at": timestamp,
+            "started_at": None,
+            "finished_at": None,
+            "pid": None,
+            "error": None,
+        },
+        EMBEDDING: {
+            "state": STATE_READY if dependency_ready(EMBEDDING) else STATE_MISSING,
+            "updated_at": timestamp,
+            "started_at": None,
+            "finished_at": None,
+            "pid": None,
+            "error": None,
+        },
+    }
+
+
+def _normalize_status_unlocked(status: dict[str, Any]) -> bool:
+    changed = False
+
+    warning = _legacy_path_warning()
+    if warning:
+        if status.get("legacy_path_warning") != warning:
+            status["legacy_path_warning"] = warning
+            changed = True
+    elif "legacy_path_warning" in status:
+        status.pop("legacy_path_warning", None)
+        changed = True
+
+    for dependency in (CORE, EMBEDDING):
+        dep_state = status["dependencies"][dependency]
+        runtime_ready = dependency_ready(dependency)
+        current_state = dep_state.get("state", STATE_MISSING)
+
+        if runtime_ready and current_state != STATE_READY:
+            dep_state.update(
+                {
+                    "state": STATE_READY,
+                    "updated_at": _timestamp(),
+                    "finished_at": dep_state.get("finished_at") or _timestamp(),
+                    "pid": None,
+                    "error": None,
+                }
+            )
+            changed = True
+            continue
+
+        if runtime_ready or current_state != STATE_INSTALLING:
+            if not runtime_ready and current_state == STATE_READY:
+                dep_state.update(
+                    {
+                        "state": STATE_MISSING,
+                        "updated_at": _timestamp(),
+                        "finished_at": None,
+                        "pid": None,
+                        "error": None,
+                    }
+                )
+                changed = True
+            continue
+
+        if dep_state.get("pid") and _pid_is_running(dep_state["pid"]):
+            continue
+
+        dep_state.update(
+            {
+                "state": STATE_FAILED,
+                "updated_at": _timestamp(),
+                "finished_at": _timestamp(),
+                "pid": None,
+                "error": dep_state.get("error")
+                or _manual_install_message(
+                    dependency,
+                    f"{dependency} dependency bootstrap exited before the runtime became available.",
+                ),
+            }
+        )
+        changed = True
+    return changed
+
+
+@lru_cache(maxsize=1)
+def _python_has_pip() -> bool:
+    result = subprocess.run(
+        [sys.executable, "-m", "pip", "--version"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def _module_available(module_name: str) -> bool:
+    return importlib.util.find_spec(module_name) is not None
+
+
+def _core_runtime_ready() -> bool:
+    return _module_available("sqlite_vec") and _sqlite_runtime_ready()
+
+
+def _sqlite_runtime_ready() -> bool:
+    if _sqlite_module_supports_extensions(stdlib_sqlite3):
+        return True
+    if not _module_available("pysqlite3"):
+        return False
+    try:
+        import pysqlite3 as pysqlite3_sqlite
+    except ImportError:
+        return False
+    return _sqlite_module_supports_extensions(pysqlite3_sqlite)
+
+
+def _sqlite_module_supports_extensions(sqlite_module: Any) -> bool:
+    try:
+        conn = sqlite_module.connect(":memory:")
+    except Exception:
+        return False
+    try:
+        return hasattr(conn, "enable_load_extension")
+    finally:
+        conn.close()
+
+
+def _pysqlite_package_name() -> str:
+    machine = platform.machine().lower()
+    if machine.startswith("arm") or machine == "aarch64":
+        return "pysqlite3"
+    return "pysqlite3-binary"
+
+
+def _pid_is_running(pid: int | None) -> bool:
+    if not pid:
+        return False
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    return True
+
+
+def _timestamp() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _available_install_command(
+    target_dir: str,
+    packages: list[str],
+) -> tuple[str, list[str]] | None:
+    if _python_has_pip():
+        command = [sys.executable, "-m", "pip", "install", "--quiet", "--target", target_dir]
+        return "pip", command + packages
+
+    uv_path = shutil.which("uv")
+    if uv_path:
+        command = [
+            uv_path,
+            "pip",
+            "install",
+            "--python",
+            sys.executable,
+            "--quiet",
+            "--no-progress",
+            "--target",
+            target_dir,
+        ]
+        return "uv", command + packages
+
+    pip_path = shutil.which("pip")
+    if pip_path:
+        command = [pip_path, "install", "--quiet", "--target", target_dir]
+        return "pip", command + packages
+
+    return None
+
+
+def _manual_install_message(
+    dependency: str,
+    detail: str,
+    install_command: list[str] | None = None,
+) -> str:
+    packages = missing_packages(dependency)
+    package_list = packages or (
+        ["sentence-transformers"]
+        if dependency == EMBEDDING
+        else [_pysqlite_package_name(), "sqlite-vec"]
+    )
+    target_dir = managed_site_dir()
+    resolved_install_command = install_command
+    if resolved_install_command is None:
+        available_install = _available_install_command(str(target_dir), package_list)
+        if available_install:
+            _, resolved_install_command = available_install
+
+    if resolved_install_command:
+        return f"{detail} Install manually with: {shlex.join(resolved_install_command)}"
+
+    return (
+        f"{detail} Install the required packages into {target_dir} using a Python environment "
+        f"with pip or uv available: {' '.join(package_list)}"
+    )
+
+
+def _path_exists(path: Path) -> bool:
+    return os.path.lexists(path)
+
+
+def _path_kind(path: Path) -> str:
+    if path.is_symlink():
+        return "symlink"
+    return "file"
+
+
+def _ensure_directory(path: Path, description: str) -> Path:
+    if _path_exists(path) and not path.is_dir():
+        raise BootstrapError(
+            f"{description} path {path} is a {_path_kind(path)}, not a directory. "
+            "Remove or rename it, then retry."
+        )
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _legacy_path_warning() -> str | None:
+    path = legacy_state_dir()
+    if not _path_exists(path) or path.is_dir():
+        return None
+    return (
+        f"Legacy runtime path {path} is a {_path_kind(path)}, not a directory. "
+        f"Compound-learning runtime state now lives in {state_dir()}. "
+        f"Remove the legacy path or reinstall dependencies into {managed_site_dir()}."
+    )
+
+
+def _result_to_text(result: BootstrapResult) -> str:
+    if result.message:
+        return result.message
+    return f"{result.dependency} dependencies: {result.state}"
+
+
+def _status_exit_code(result: BootstrapResult) -> int:
+    return 0 if result.state in {STATE_READY, STATE_INSTALLING, "started"} else 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Compound-learning dependency bootstrap")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    ensure_parser = subparsers.add_parser("ensure", help="Ensure a dependency group is ready")
+    ensure_parser.add_argument("dependency", choices=[CORE, EMBEDDING])
+    ensure_parser.add_argument("--background", action="store_true")
+    ensure_parser.add_argument("--foreground", action="store_true", help=argparse.SUPPRESS)
+    ensure_parser.add_argument("--json", action="store_true")
+    ensure_parser.add_argument("--quiet", action="store_true")
+
+    status_parser = subparsers.add_parser("status", help="Print bootstrap status")
+    status_parser.add_argument("--json", action="store_true")
+
+    args = parser.parse_args(argv)
+
+    if args.command == "status":
+        status = read_status()
+        if args.json:
+            print(json.dumps(status))
+        else:
+            print(json.dumps(status, indent=2))
+        return 0
+
+    wait = not args.background or args.foreground
+    background = args.background and not args.foreground
+    try:
+        result = ensure_dependency(args.dependency, wait=wait, background=background)
+    except BootstrapError as exc:
+        result = BootstrapResult(
+            dependency=args.dependency,
+            state=STATE_FAILED,
+            error=str(exc),
+            message=str(exc),
+            warning=_legacy_path_warning(),
+        )
+
+    if args.json:
+        print(json.dumps(result.to_dict()))
+    elif not args.quiet:
+        print(_result_to_text(result))
+        if result.warning:
+            print(result.warning, file=sys.stderr)
+
+    return _status_exit_code(result)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/compound-learning/lib/db.py
+++ b/plugins/compound-learning/lib/db.py
@@ -6,30 +6,16 @@ All four Python scripts import from here instead of duplicating database boilerp
 
 import json
 import os
+import sqlite3 as stdlib_sqlite3
 import sys
 import threading
 from pathlib import Path
 from typing import Any, Dict, List
 
-try:
-    import sqlite3
-    _test_conn = sqlite3.connect(':memory:')
-    if not hasattr(_test_conn, 'enable_load_extension'):
-        raise AttributeError('no enable_load_extension')
-    _test_conn.close()
-except AttributeError:
-    try:
-        import pysqlite3 as sqlite3  # type: ignore[no-redef]
-    except ImportError:
-        import platform
-        is_arm = platform.machine().startswith('arm') or platform.machine() == 'aarch64'
-        pkg = 'pysqlite3' if is_arm else 'pysqlite3-binary'
-        print(
-            '[ERROR] sqlite3 extension loading is not available.\n'
-            'Install the required dependency:\n'
-            f'  pip install {pkg}'
-        )
-        raise
+from . import bootstrap
+
+sqlite3 = stdlib_sqlite3
+_sqlite_module = None
 
 _model = None
 _model_lock = threading.Lock()
@@ -115,23 +101,55 @@ def _deep_merge(base: Dict, override: Dict) -> Dict:
     return result
 
 
-def get_connection(config: Dict[str, Any]) -> sqlite3.Connection:
+def _sqlite_module_supports_extensions(sqlite_module: Any) -> bool:
+    try:
+        conn = sqlite_module.connect(':memory:')
+    except Exception:
+        return False
+    try:
+        return hasattr(conn, 'enable_load_extension')
+    finally:
+        conn.close()
+
+
+def _get_sqlite_module() -> Any:
+    global _sqlite_module
+    if _sqlite_module is not None:
+        return _sqlite_module
+
+    if _sqlite_module_supports_extensions(stdlib_sqlite3):
+        _sqlite_module = stdlib_sqlite3
+        return _sqlite_module
+
+    bootstrap.ensure_core_dependencies()
+    try:
+        import pysqlite3 as pysqlite3_sqlite
+    except ImportError as exc:
+        raise RuntimeError(
+            'sqlite3 extension loading is still unavailable after core dependency bootstrap'
+        ) from exc
+
+    _sqlite_module = pysqlite3_sqlite
+    return _sqlite_module
+
+
+def get_connection(config: Dict[str, Any]) -> Any:
     """Open SQLite DB, load sqlite-vec extension, create schema if missing."""
+    bootstrap.ensure_core_dependencies()
+    sqlite_module = _get_sqlite_module()
+
     try:
         import sqlite_vec
-    except ImportError:
-        print(
-            '[ERROR] sqlite-vec is not installed.\n'
-            'Install the required dependency:\n'
-            '  pip install sqlite-vec'
-        )
-        raise
+    except ImportError as exc:
+        raise RuntimeError(
+            'sqlite-vec is still unavailable after core dependency bootstrap'
+        ) from exc
 
     db_path = config['sqlite']['dbPath']
     os.makedirs(os.path.dirname(db_path), exist_ok=True)
 
-    conn = sqlite3.connect(db_path)
-    conn.row_factory = sqlite3.Row
+    conn = sqlite_module.connect(db_path)
+    conn.row_factory = sqlite_module.Row
 
     conn.enable_load_extension(True)
     sqlite_vec.load(conn)
@@ -141,7 +159,7 @@ def get_connection(config: Dict[str, Any]) -> sqlite3.Connection:
     return conn
 
 
-def _create_schema(conn: sqlite3.Connection) -> None:
+def _create_schema(conn: Any) -> None:
     conn.executescript("""
         CREATE TABLE IF NOT EXISTS learnings (
             id TEXT PRIMARY KEY,
@@ -173,6 +191,7 @@ def get_embedding(text: str):
     global _model
     with _model_lock:
         if _model is None:
+            bootstrap.ensure_embedding_dependencies()
             model_cache = os.path.expanduser(
                 '~/.cache/huggingface/hub/models--sentence-transformers--all-MiniLM-L6-v2'
             )
@@ -180,19 +199,16 @@ def get_embedding(text: str):
                 print("Downloading embedding model (one-time, ~80MB)...", file=sys.stderr)
             try:
                 from sentence_transformers import SentenceTransformer
-            except ImportError:
-                print(
-                    '[ERROR] sentence-transformers is not installed.\n'
-                    'Install the required dependency:\n'
-                    '  pip install sentence-transformers'
-                )
-                raise
+            except ImportError as exc:
+                raise RuntimeError(
+                    'sentence-transformers is still unavailable after embedding bootstrap'
+                ) from exc
             _model = SentenceTransformer('all-MiniLM-L6-v2')
     return _model.encode(text, normalize_embeddings=True).tolist()
 
 
 def upsert_document(
-    conn: sqlite3.Connection,
+    conn: Any,
     doc_id: str,
     content: str,
     metadata: Dict[str, Any],
@@ -236,7 +252,7 @@ def upsert_document(
     conn.commit()
 
 
-def delete_document(conn: sqlite3.Connection, doc_id: str) -> None:
+def delete_document(conn: Any, doc_id: str) -> None:
     """Remove a document from all three tables."""
     conn.execute("DELETE FROM learnings WHERE id = ?", (doc_id,))
     conn.execute("DELETE FROM vec_learnings WHERE id = ?", (doc_id,))
@@ -245,7 +261,7 @@ def delete_document(conn: sqlite3.Connection, doc_id: str) -> None:
 
 
 def search(
-    conn: sqlite3.Connection,
+    conn: Any,
     query_text: str,
     scope_repos: List[str],
     n_results: int = 10,
@@ -312,7 +328,7 @@ def search(
 
 
 def get_all_documents(
-    conn: sqlite3.Connection, include_content: bool = True
+    conn: Any, include_content: bool = True
 ) -> Dict[str, Any]:
     """Return all documents in a dict format compatible with consolidate-discovery."""
     rows = conn.execute(
@@ -338,7 +354,7 @@ def get_all_documents(
 
 
 def get_documents_by_ids(
-    conn: sqlite3.Connection, ids: List[str]
+    conn: Any, ids: List[str]
 ) -> Dict[str, Any]:
     """Fetch specific documents by ID list."""
     if not ids:
@@ -372,7 +388,7 @@ def get_documents_by_ids(
     return {'ids': result_ids, 'documents': result_docs, 'metadatas': result_metas}
 
 
-def count_documents(conn: sqlite3.Connection) -> int:
+def count_documents(conn: Any) -> int:
     """Return total number of indexed documents."""
     row = conn.execute("SELECT COUNT(*) FROM learnings").fetchone()
     return row[0] if row else 0

--- a/plugins/compound-learning/tests/test_dependency_bootstrap.py
+++ b/plugins/compound-learning/tests/test_dependency_bootstrap.py
@@ -1,0 +1,214 @@
+import importlib.util
+import json
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+
+BOOTSTRAP_PATH = Path(__file__).resolve().parent.parent / "lib" / "bootstrap.py"
+
+
+@pytest.fixture
+def load_bootstrap(monkeypatch):
+    loaded_modules = []
+
+    def _load(home: Path):
+        monkeypatch.setenv("HOME", str(home))
+        module_name = f"compound_learning_bootstrap_test_{uuid.uuid4().hex}"
+        spec = importlib.util.spec_from_file_location(module_name, BOOTSTRAP_PATH)
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        sys.modules[module_name] = module
+        spec.loader.exec_module(module)
+        module._python_has_pip.cache_clear()
+        loaded_modules.append((module_name, module))
+        return module
+
+    yield _load
+
+    for module_name, module in loaded_modules:
+        module._python_has_pip.cache_clear()
+        sys.modules.pop(module_name, None)
+
+
+def test_import_isolation_avoids_runtime_side_effects(load_bootstrap, tmp_path):
+    bootstrap = load_bootstrap(tmp_path)
+
+    assert bootstrap.state_dir() == tmp_path / ".claude" / "state" / "compound-learning"
+    assert not bootstrap.state_dir().exists()
+    assert not bootstrap.log_file().exists()
+    assert str(bootstrap.managed_site_dir()) not in sys.path
+
+
+@pytest.mark.parametrize("kind", ["broken_symlink", "file"])
+def test_legacy_runtime_path_conflicts_are_reported_without_crashing(
+    kind,
+    load_bootstrap,
+    tmp_path,
+):
+    legacy_path = tmp_path / ".claude" / "plugins" / "compound-learning"
+    legacy_path.parent.mkdir(parents=True, exist_ok=True)
+    if kind == "broken_symlink":
+        legacy_path.symlink_to(tmp_path / "missing-plugin-root")
+    else:
+        legacy_path.write_text("not a directory", encoding="utf-8")
+
+    bootstrap = load_bootstrap(tmp_path)
+
+    status = bootstrap.read_status()
+    warning = status["legacy_path_warning"]
+
+    assert str(legacy_path) in warning
+    assert str(bootstrap.state_dir()) in warning
+    assert str(bootstrap.managed_site_dir()) in warning
+    assert bootstrap.status_file().exists()
+
+
+def test_missing_packages_distinguishes_core_and_embedding(load_bootstrap, tmp_path, monkeypatch):
+    bootstrap = load_bootstrap(tmp_path)
+    available = {
+        "sqlite_vec": False,
+        "sentence_transformers": False,
+        "pysqlite3": False,
+    }
+
+    monkeypatch.setattr(bootstrap, "_module_available", lambda name: available.get(name, False))
+    monkeypatch.setattr(bootstrap, "_sqlite_module_supports_extensions", lambda module: False)
+    monkeypatch.setattr(bootstrap, "_pysqlite_package_name", lambda: "pysqlite3-binary")
+
+    assert bootstrap.missing_packages(bootstrap.CORE) == ["pysqlite3-binary", "sqlite-vec"]
+    assert bootstrap.missing_packages(bootstrap.EMBEDDING) == ["sentence-transformers"]
+
+    available["sqlite_vec"] = True
+    assert bootstrap.missing_packages(bootstrap.CORE) == ["pysqlite3-binary"]
+
+
+def test_stale_install_state_becomes_failed_and_can_recover(load_bootstrap, tmp_path, monkeypatch):
+    bootstrap = load_bootstrap(tmp_path)
+    ready = {
+        bootstrap.CORE: True,
+        bootstrap.EMBEDDING: False,
+    }
+
+    monkeypatch.setattr(bootstrap, "dependency_ready", lambda dependency: ready[dependency])
+    monkeypatch.setattr(bootstrap, "_pid_is_running", lambda pid: False)
+
+    stale_status = {
+        "dependencies": {
+            bootstrap.CORE: {
+                "state": bootstrap.STATE_READY,
+                "updated_at": "2026-01-01T00:00:00+00:00",
+                "started_at": None,
+                "finished_at": None,
+                "pid": None,
+                "error": None,
+            },
+            bootstrap.EMBEDDING: {
+                "state": bootstrap.STATE_INSTALLING,
+                "updated_at": "2026-01-01T00:00:00+00:00",
+                "started_at": "2026-01-01T00:00:00+00:00",
+                "finished_at": None,
+                "pid": 424242,
+                "error": None,
+            },
+        }
+    }
+    bootstrap.status_file().parent.mkdir(parents=True, exist_ok=True)
+    bootstrap.status_file().write_text(json.dumps(stale_status), encoding="utf-8")
+
+    status = bootstrap.read_status()
+    failed_state = status["dependencies"][bootstrap.EMBEDDING]
+    assert failed_state["state"] == bootstrap.STATE_FAILED
+    assert "exited before the runtime became available" in failed_state["error"]
+
+    monkeypatch.setattr(
+        bootstrap,
+        "missing_packages",
+        lambda dependency: [] if ready[dependency] else ["sentence-transformers"],
+    )
+
+    def fake_install(dependency, packages):
+        assert dependency == bootstrap.EMBEDDING
+        assert packages == ["sentence-transformers"]
+        ready[dependency] = True
+        return "fake-installer"
+
+    monkeypatch.setattr(bootstrap, "_install_packages", fake_install)
+
+    result = bootstrap.ensure_embedding_dependencies()
+    assert result.state == bootstrap.STATE_READY
+    assert result.backend == "fake-installer"
+
+    recovered_status = bootstrap.read_status()
+    assert recovered_status["dependencies"][bootstrap.EMBEDDING]["state"] == bootstrap.STATE_READY
+
+
+def test_embedding_no_installer_message_avoids_pip_guidance_and_uses_embedding_packages(
+    load_bootstrap,
+    tmp_path,
+    monkeypatch,
+):
+    bootstrap = load_bootstrap(tmp_path)
+
+    monkeypatch.setattr(bootstrap, "dependency_ready", lambda dependency: False)
+    monkeypatch.setattr(
+        bootstrap,
+        "missing_packages",
+        lambda dependency: ["sentence-transformers"] if dependency == bootstrap.EMBEDDING else [],
+    )
+
+    def fake_python_has_pip():
+        return False
+
+    fake_python_has_pip.cache_clear = lambda: None
+
+    monkeypatch.setattr(bootstrap, "_python_has_pip", fake_python_has_pip)
+    monkeypatch.setattr(bootstrap.shutil, "which", lambda name: None)
+
+    with pytest.raises(bootstrap.BootstrapError) as exc_info:
+        bootstrap.ensure_embedding_dependencies()
+
+    message = str(exc_info.value)
+    assert "sentence-transformers" in message
+    assert "sqlite-vec" not in message
+    assert "pysqlite3" not in message
+    assert "pip install --target" not in message
+    assert "using a Python environment with pip or uv available" in message
+    assert str(bootstrap.managed_site_dir()) in message
+
+
+def test_prepare_embedding_for_auto_peek_is_non_blocking(load_bootstrap, tmp_path, monkeypatch):
+    bootstrap = load_bootstrap(tmp_path)
+    ready = {
+        bootstrap.CORE: True,
+        bootstrap.EMBEDDING: False,
+    }
+    spawn_calls = []
+
+    monkeypatch.setattr(bootstrap, "dependency_ready", lambda dependency: ready[dependency])
+    monkeypatch.setattr(
+        bootstrap,
+        "missing_packages",
+        lambda dependency: [] if ready[dependency] else ["sentence-transformers"],
+    )
+    monkeypatch.setattr(
+        bootstrap,
+        "_spawn_background_install",
+        lambda dependency: spawn_calls.append(dependency) or 98765,
+    )
+    monkeypatch.setattr(bootstrap, "_pid_is_running", lambda pid: pid == 98765)
+
+    first = bootstrap.prepare_embedding_for_auto_peek()
+    second = bootstrap.prepare_embedding_for_auto_peek()
+
+    assert first.state == "started"
+    assert first.pid == 98765
+    assert second.state == bootstrap.STATE_INSTALLING
+    assert second.pid == 98765
+    assert spawn_calls == [bootstrap.EMBEDDING]
+
+    status = bootstrap.read_status()
+    embedding_state = status["dependencies"][bootstrap.EMBEDDING]
+    assert embedding_state["state"] == bootstrap.STATE_INSTALLING
+    assert embedding_state["pid"] == 98765


### PR DESCRIPTION
## Summary
- move compound-learning runtime state out of the plugin install path and keep bootstrap filesystem effects lazy
- update hooks/docs/tests for the dedicated runtime state root and legacy-path conflict handling
- keep no-installer remediation accurate by dropping hardcoded pip guidance when neither pip nor uv is available

## Verification
- pytest -q plugins/compound-learning/tests/test_dependency_bootstrap.py
- pytest -q plugins/compound-learning/tests
- python3 -m compileall plugins/compound-learning
- git diff --check main...bug-finder/compound-learning-runtime-state-iter3