### PR TITLE
Fix compound-learning lint issues

### DIFF
--- a/plugins/compound-learning/scripts/backfill-topics.py
+++ b/plugins/compound-learning/scripts/backfill-topics.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# ruff: noqa: E402
 """
 Backfill missing **Topic:** fields in learning markdown files.
 

--- a/plugins/compound-learning/scripts/search-learnings.py
+++ b/plugins/compound-learning/scripts/search-learnings.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# ruff: noqa: E402
 """
 Search learnings in SQLite with distance threshold filtering.
 Filters results before outputting to avoid context pollution.

--- a/plugins/compound-learning/skills/consolidate-actions/consolidate-actions.py
+++ b/plugins/compound-learning/skills/consolidate-actions/consolidate-actions.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# ruff: noqa: E402
 """
 Execute consolidation actions: merge, archive, delete, rescope, get.
 All destructive operations create backups first.
@@ -293,7 +294,7 @@ def action_merge(ids: List[str], name: str, config: Dict[str, Any],
 
         # Build structured merged content
         merged_content = f"# {name.replace('-', ' ').title()}\n\n"
-        merged_content += f"**Type:** pattern\n"
+        merged_content += "**Type:** pattern\n"
         merged_content += f"**Topic:** {merged_topic}\n"
         merged_content += f"**Tags:** {merged_tags}\n\n"
         merged_content += f"*Merged from {len(contents)} learnings on {date_str}*\n\n"

--- a/plugins/compound-learning/skills/consolidate-discovery/consolidate-discovery.py
+++ b/plugins/compound-learning/skills/consolidate-discovery/consolidate-discovery.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# ruff: noqa: E402
 """
 Discover consolidation candidates in SQLite.
 Returns compact output to avoid token bloat.

--- a/plugins/compound-learning/skills/index-learnings/index-learnings.py
+++ b/plugins/compound-learning/skills/index-learnings/index-learnings.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# ruff: noqa: E402
 """
 Index all learning markdown files into SQLite + sqlite-vec.
 Generates a manifest summarizing learnings by topic for CLAUDE.md integration.
@@ -157,7 +158,7 @@ def generate_manifest(manifest_data: Dict[str, List[Dict[str, Any]]], config: Di
 def _format_section(title: str, learnings: List[Dict[str, Any]]) -> List[str]:
     """Format a manifest section."""
     total = len(learnings)
-    gotchas = sum(1 for l in learnings if l.get('is_gotcha'))
+    gotchas = sum(1 for learning in learnings if learning.get('is_gotcha'))
 
     lines = []
     if gotchas > 0:
@@ -169,12 +170,12 @@ def _format_section(title: str, learnings: List[Dict[str, Any]]) -> List[str]:
     # Aggregate by topic
     topics: Dict[str, Dict] = defaultdict(lambda: {'count': 0, 'keywords': defaultdict(int), 'gotchas': 0})
 
-    for l in learnings:
-        topic = l['topic']
+    for learning in learnings:
+        topic = learning['topic']
         topics[topic]['count'] += 1
-        if l.get('is_gotcha'):
+        if learning.get('is_gotcha'):
             topics[topic]['gotchas'] += 1
-        for kw in l.get('keywords', []):
+        for kw in learning.get('keywords', []):
             topics[topic]['keywords'][kw] += 1
 
     # Table sorted by count
@@ -228,7 +229,7 @@ def index_learning_files():
     print("Opening database...")
     try:
         conn = db.get_connection(config)
-        print(f"[OK] Database ready")
+        print("[OK] Database ready")
     except Exception as e:
         print(f"[ERROR] Failed to open database: {e}")
         sys.exit(1)

--- a/plugins/compound-learning/tests/test_search_relevance.py
+++ b/plugins/compound-learning/tests/test_search_relevance.py
@@ -1,3 +1,4 @@
+# ruff: noqa: E402
 """
 E2E tests for compound-learning search relevance.
 
@@ -6,13 +7,9 @@ real SQLite/sqlite-vec/fts5, real indexing, and real reranking logic.
 No internal modules are mocked.
 """
 
-import json
-import os
 import sys
-import tempfile
-import uuid
 from pathlib import Path
-from typing import Any, Dict, List, Set
+from typing import Any, Dict, List
 
 import pytest
 
@@ -202,7 +199,7 @@ def test_relevant_results_ranked_above_irrelevant(tmp_db):
         f"Expected PDF learning in results but got ids: {all_ids}"
     )
     assert GRAFANA_LEARNING[0] not in all_ids, (
-        f"Grafana learning should be excluded (zero keyword overlap with 'slash command pdf layout')"
+        "Grafana learning should be excluded (zero keyword overlap with 'slash command pdf layout')"
     )
 
 
@@ -363,7 +360,6 @@ def test_fts5_boost_helps_stemmed_matches(tmp_db):
 
     stem_raw = next((r for r in raw if r["id"] == stem_doc_id), None)
     assert stem_raw is not None, "stem doc not found in raw KNN results"
-    original_distance = stem_raw["distance"]
 
     # Rerank with FTS5 boost
     reranked_with_fts = hybrid_rerank(
@@ -386,7 +382,7 @@ def test_fts5_boost_helps_stemmed_matches(tmp_db):
         f"FTS5 boost should lower distance: with={with_fts['distance']} without={without_fts['distance']}"
     )
     assert abs(with_fts["distance"] - (without_fts["distance"] - 0.05)) < 0.001, (
-        f"Expected 0.05 reduction from FTS5 boost"
+        "Expected 0.05 reduction from FTS5 boost"
     )
 
 


### PR DESCRIPTION
## Summary
- suppress file-local `E402` in compound-learning entrypoints that intentionally bootstrap `CLAUDE_PLUGIN_ROOT`
- keep the safe Ruff autofixes for redundant f-strings and unused imports in the touched lint scope
- fix the remaining real issues by renaming ambiguous loop variables in `index-learnings` and dropping an unused test local

## Verification
- `uvx ruff check plugins/compound-learning`
- `pytest plugins/compound-learning/tests/test_search_relevance.py -q`
- verified top-level imports for the touched entrypoints from `/tmp` with `CLAUDE_PLUGIN_ROOT` set