### PR TITLE
Add hit count and access frequency tracking for learnings

### DIFF
--- a/plugins/compound-learning/lib/db.py
+++ b/plugins/compound-learning/lib/db.py
@@ -167,6 +167,17 @@ def _create_schema(conn: sqlite3.Connection) -> None:
     """)
     conn.commit()
 
+    # Idempotent migration: add hit-count columns
+    for col, col_def in [
+        ('access_count', 'INTEGER DEFAULT 0'),
+        ('last_accessed', 'TEXT'),
+    ]:
+        try:
+            conn.execute(f"ALTER TABLE learnings ADD COLUMN {col} {col_def}")
+            conn.commit()
+        except sqlite3.OperationalError:
+            pass  # Column already exists
+
 
 def get_embedding(text: str):
     """Lazy-load sentence-transformers model and return embedding as list."""
@@ -207,8 +218,8 @@ def upsert_document(
     delete_document(conn, doc_id)
 
     conn.execute(
-        """INSERT INTO learnings (id, content, scope, repo, file_path, topic, keywords, created_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+        """INSERT INTO learnings (id, content, scope, repo, file_path, topic, keywords, created_at, access_count, last_accessed)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (
             doc_id,
             content,
@@ -218,6 +229,8 @@ def upsert_document(
             metadata.get('topic', 'other'),
             metadata.get('keywords', ''),
             created_at,
+            metadata.get('access_count', 0),
+            metadata.get('last_accessed', None),
         ),
     )
 
@@ -275,7 +288,7 @@ def search(
     rows = conn.execute(
         f"""
         SELECT l.id, l.content, l.scope, l.repo, l.file_path, l.topic, l.keywords,
-               v.distance
+               l.access_count, l.last_accessed, v.distance
         FROM vec_learnings v
         JOIN learnings l ON l.id = v.id
         WHERE v.embedding MATCH ?
@@ -302,6 +315,8 @@ def search(
                 'file_path': row['file_path'],
                 'topic': row['topic'],
                 'keywords': row['keywords'],
+                'access_count': row['access_count'],
+                'last_accessed': row['last_accessed'],
             },
             'distance': round(dist, 4),
         })
@@ -370,6 +385,15 @@ def get_documents_by_ids(
             })
 
     return {'ids': result_ids, 'documents': result_docs, 'metadatas': result_metas}
+
+
+def increment_hit_count(conn: sqlite3.Connection, doc_id: str, timestamp: str) -> None:
+    """Increment access_count by 1 and update last_accessed for a document."""
+    conn.execute(
+        "UPDATE learnings SET access_count = access_count + 1, last_accessed = ? WHERE id = ?",
+        (timestamp, doc_id),
+    )
+    conn.commit()
 
 
 def count_documents(conn: sqlite3.Connection) -> int:

--- a/plugins/compound-learning/lib/hit_tracker.py
+++ b/plugins/compound-learning/lib/hit_tracker.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Track hit counts for accessed learnings in both SQLite and markdown files."""
+
+import os
+import re
+import sys
+from datetime import date
+
+_PLUGIN_ROOT = os.environ.get('CLAUDE_PLUGIN_ROOT', os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, _PLUGIN_ROOT)
+
+import lib.db as db
+
+
+def record_hits(config: dict, results: list[dict], today: str | None = None) -> None:
+    """Record hit counts for search results in SQLite and learning files.
+
+    Args:
+        config: Plugin configuration dict (passed to db.get_connection).
+        results: List of search result dicts with 'id' and 'metadata.file_path'.
+        today: Date string YYYY-MM-DD; defaults to current date.
+    """
+    if today is None:
+        today = date.today().isoformat()
+
+    conn = db.get_connection(config)
+    try:
+        for result in results:
+            file_path = result.get('metadata', {}).get('file_path', '')
+            if not file_path:
+                continue
+
+            doc_id = result['id']
+
+            try:
+                db.increment_hit_count(conn, doc_id, today)
+            except Exception as e:
+                print(f"[WARN] DB hit increment failed for {doc_id}: {e}", file=sys.stderr)
+
+            try:
+                _update_file_hits(file_path, today)
+            except Exception as e:
+                print(f"[WARN] File hit update failed for {file_path}: {e}", file=sys.stderr)
+    finally:
+        conn.close()
+
+
+def _update_file_hits(file_path: str, today: str) -> None:
+    """Update **Hits:** and **Last Accessed:** fields in a learning markdown file."""
+    if not os.path.isfile(file_path):
+        return
+
+    with open(file_path, 'r', encoding='utf-8') as f:
+        content = f.read()
+
+    content = _update_or_insert_hits(content)
+    content = _update_or_insert_last_accessed(content, today)
+
+    with open(file_path, 'w', encoding='utf-8') as f:
+        f.write(content)
+
+
+def _update_or_insert_hits(content: str) -> str:
+    """Increment **Hits:** N by 1, or insert **Hits:** 1 after the last **Field:** line."""
+    hits_pattern = re.compile(r'^(\*\*Hits:\*\*\s*)(\d+)', re.MULTILINE)
+    match = hits_pattern.search(content)
+    if match:
+        new_count = int(match.group(2)) + 1
+        return hits_pattern.sub(rf'\g<1>{new_count}', content, count=1)
+
+    return _insert_field_after_last_metadata(content, '**Hits:** 1')
+
+
+def _update_or_insert_last_accessed(content: str, today: str) -> str:
+    """Update **Last Accessed:** date, or insert it after the last **Field:** line."""
+    la_pattern = re.compile(r'^(\*\*Last Accessed:\*\*\s*).*$', re.MULTILINE)
+    match = la_pattern.search(content)
+    if match:
+        return la_pattern.sub(rf'\g<1>{today}', content, count=1)
+
+    return _insert_field_after_last_metadata(content, f'**Last Accessed:** {today}')
+
+
+def _insert_field_after_last_metadata(content: str, field_line: str) -> str:
+    """Insert a field line after the last **Key:** value line in the frontmatter block."""
+    field_pattern = re.compile(r'^\*\*\w[\w\s]*:\*\*.*$', re.MULTILINE)
+    last_match = None
+    for m in field_pattern.finditer(content):
+        last_match = m
+
+    if last_match:
+        insert_pos = last_match.end()
+        return content[:insert_pos] + '\n' + field_line + content[insert_pos:]
+
+    return content

--- a/plugins/compound-learning/scripts/search-learnings.py
+++ b/plugins/compound-learning/scripts/search-learnings.py
@@ -320,6 +320,14 @@ def search_learnings(
                 output = {'status': 'empty', 'keywords_searched': keywords}
 
             print(json.dumps(output, indent=2))
+
+            if peek_results:
+                try:
+                    from lib.hit_tracker import record_hits
+                    record_hits(config, peek_results)
+                except Exception as e:
+                    print(f"[WARN] Hit tracking failed: {e}", file=sys.stderr)
+
             return
 
         # Build output

--- a/plugins/compound-learning/skills/index-learnings/index-learnings.py
+++ b/plugins/compound-learning/skills/index-learnings/index-learnings.py
@@ -125,6 +125,22 @@ def extract_type(content: str) -> str | None:
     return extract_field(content, 'Type')
 
 
+def extract_hits(content: str) -> int:
+    """Extract hit count from **Hits:** field, default 0."""
+    raw = extract_field(content, 'Hits')
+    if raw:
+        try:
+            return int(raw)
+        except ValueError:
+            return 0
+    return 0
+
+
+def extract_last_accessed(content: str) -> str | None:
+    """Extract last accessed date from **Last Accessed:** field."""
+    return extract_field(content, 'Last Accessed')
+
+
 def generate_manifest(manifest_data: Dict[str, List[Dict[str, Any]]], config: Dict[str, Any]) -> None:
     """Generate single manifest file at ~/.projects/learnings/MANIFEST.md"""
     global_dir = Path(config['learnings']['globalDir'])
@@ -209,6 +225,8 @@ def index_single_file(file_path: Path, config: Dict[str, Any]) -> bool:
 
         metadata['topic'] = topic
         metadata['keywords'] = ','.join(keywords)
+        metadata['access_count'] = extract_hits(content)
+        metadata['last_accessed'] = extract_last_accessed(content)
 
         doc_id = hashlib.md5(str(file_path.resolve()).encode()).hexdigest()
         db.upsert_document(conn, doc_id, content, metadata)
@@ -260,6 +278,8 @@ def index_learning_files():
 
             metadata['topic'] = topic
             metadata['keywords'] = ','.join(keywords)
+            metadata['access_count'] = extract_hits(content)
+            metadata['last_accessed'] = extract_last_accessed(content)
 
             doc_id = hashlib.md5(str(file_path.resolve()).encode()).hexdigest()
             db.upsert_document(conn, doc_id, content, metadata)

--- a/plugins/compound-learning/tests/test_hit_count_indexing.py
+++ b/plugins/compound-learning/tests/test_hit_count_indexing.py
@@ -1,0 +1,234 @@
+"""
+Tests for hit count schema migration, upsert, increment, and indexer integration.
+
+Uses real SQLite (no mocks for internal modules).
+"""
+
+import hashlib
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+PLUGIN_ROOT = str(Path(__file__).parent.parent)
+sys.path.insert(0, PLUGIN_ROOT)
+
+import lib.db as db
+
+_idx_spec = importlib.util.spec_from_file_location(
+    "index_learnings",
+    Path(PLUGIN_ROOT) / "skills" / "index-learnings" / "index-learnings.py",
+)
+_idx_mod = importlib.util.module_from_spec(_idx_spec)
+_idx_spec.loader.exec_module(_idx_mod)
+
+extract_hits = _idx_mod.extract_hits
+extract_last_accessed = _idx_mod.extract_last_accessed
+index_single_file = _idx_mod.index_single_file
+
+
+@pytest.fixture(scope="module")
+def embedding_model():
+    db.get_embedding("warmup")
+    yield
+
+
+@pytest.fixture()
+def tmp_db(tmp_path, embedding_model):
+    db_path = str(tmp_path / "test.db")
+    config = {
+        "sqlite": {"dbPath": db_path},
+        "learnings": {
+            "globalDir": str(tmp_path / "learnings"),
+            "repoSearchPath": str(tmp_path),
+            "highConfidenceThreshold": 0.40,
+            "possiblyRelevantThreshold": 0.55,
+            "keywordBoostWeight": 0.65,
+        },
+    }
+    conn = db.get_connection(config)
+    yield config, conn
+    conn.close()
+
+
+def test_schema_has_access_count_and_last_accessed(tmp_db):
+    _, conn = tmp_db
+    rows = conn.execute("PRAGMA table_info(learnings)").fetchall()
+    col_names = {row["name"] for row in rows}
+    assert "access_count" in col_names
+    assert "last_accessed" in col_names
+
+
+def test_upsert_with_access_count(tmp_db):
+    _, conn = tmp_db
+    db.upsert_document(
+        conn,
+        "doc-ac-5",
+        "test content for access count",
+        {
+            "scope": "global",
+            "repo": "",
+            "file_path": "/tmp/test.md",
+            "topic": "testing",
+            "keywords": "test",
+            "access_count": 5,
+            "last_accessed": "2026-03-13",
+        },
+    )
+    row = conn.execute(
+        "SELECT access_count, last_accessed FROM learnings WHERE id = ?",
+        ("doc-ac-5",),
+    ).fetchone()
+    assert row["access_count"] == 5
+    assert row["last_accessed"] == "2026-03-13"
+
+
+def test_upsert_default_access_count(tmp_db):
+    _, conn = tmp_db
+    db.upsert_document(
+        conn,
+        "doc-default-ac",
+        "test content no access count",
+        {
+            "scope": "global",
+            "repo": "",
+            "file_path": "/tmp/test2.md",
+            "topic": "testing",
+            "keywords": "test",
+        },
+    )
+    row = conn.execute(
+        "SELECT access_count, last_accessed FROM learnings WHERE id = ?",
+        ("doc-default-ac",),
+    ).fetchone()
+    assert row["access_count"] == 0
+    assert row["last_accessed"] is None
+
+
+def test_increment_hit_count(tmp_db):
+    _, conn = tmp_db
+    db.upsert_document(
+        conn,
+        "doc-inc",
+        "test content for increment",
+        {
+            "scope": "global",
+            "repo": "",
+            "file_path": "/tmp/test3.md",
+            "topic": "testing",
+            "keywords": "test",
+        },
+    )
+    db.increment_hit_count(conn, "doc-inc", "2026-03-13")
+    db.increment_hit_count(conn, "doc-inc", "2026-03-13")
+    row = conn.execute(
+        "SELECT access_count, last_accessed FROM learnings WHERE id = ?",
+        ("doc-inc",),
+    ).fetchone()
+    assert row["access_count"] == 2
+    assert row["last_accessed"] == "2026-03-13"
+
+
+def test_search_returns_access_count(tmp_db):
+    _, conn = tmp_db
+    db.upsert_document(
+        conn,
+        "doc-search-ac",
+        "unique xylophone content for search access count verification",
+        {
+            "scope": "global",
+            "repo": "",
+            "file_path": "/tmp/test4.md",
+            "topic": "testing",
+            "keywords": "xylophone",
+            "access_count": 3,
+            "last_accessed": "2026-03-10",
+        },
+    )
+    results = db.search(conn, "unique xylophone content", scope_repos=[], n_results=10, threshold=1.0)
+    matched = [r for r in results if r["id"] == "doc-search-ac"]
+    assert len(matched) == 1
+    assert matched[0]["metadata"]["access_count"] == 3
+
+
+def test_extract_hits_parses_correctly():
+    assert extract_hits("**Hits:** 42\n**Topic:** testing") == 42
+    assert extract_hits("No hits field here") == 0
+    assert extract_hits("**Hits:** notanumber") == 0
+
+
+def test_extract_last_accessed_parses_correctly():
+    assert extract_last_accessed("**Last Accessed:** 2026-03-13\n") == "2026-03-13"
+    assert extract_last_accessed("No last accessed field") is None
+
+
+def test_indexer_reads_hits_from_file(tmp_path, embedding_model):
+    learnings_dir = tmp_path / "learnings"
+    learnings_dir.mkdir(parents=True)
+    learning_file = learnings_dir / "test-learning.md"
+    learning_file.write_text(
+        "# Test Learning\n\n"
+        "**Type:** pattern\n"
+        "**Topic:** testing\n"
+        "**Tags:** test, example\n"
+        "**Hits:** 10\n"
+        "**Last Accessed:** 2026-03-01\n\n"
+        "## Problem\n\nThis is the problem.\n\n"
+        "## Solution\n\nThis is the solution.\n",
+        encoding="utf-8",
+    )
+
+    db_path = str(tmp_path / "indexer-test.db")
+    config = {
+        "sqlite": {"dbPath": db_path},
+        "learnings": {
+            "globalDir": str(learnings_dir),
+            "repoSearchPath": str(tmp_path),
+            "highConfidenceThreshold": 0.40,
+            "possiblyRelevantThreshold": 0.55,
+            "keywordBoostWeight": 0.65,
+        },
+    }
+
+    success = index_single_file(learning_file, config)
+    assert success is True
+
+    conn = db.get_connection(config)
+    try:
+        doc_id = hashlib.md5(str(learning_file.resolve()).encode()).hexdigest()
+        row = conn.execute(
+            "SELECT access_count, last_accessed FROM learnings WHERE id = ?",
+            (doc_id,),
+        ).fetchone()
+        assert row is not None
+        assert row["access_count"] == 10
+        assert row["last_accessed"] == "2026-03-01"
+    finally:
+        conn.close()
+
+
+def test_schema_migration_idempotent(tmp_path, embedding_model):
+    db_path = str(tmp_path / "migration-test.db")
+    config = {
+        "sqlite": {"dbPath": db_path},
+        "learnings": {
+            "globalDir": str(tmp_path / "learnings"),
+            "repoSearchPath": str(tmp_path),
+            "highConfidenceThreshold": 0.40,
+            "possiblyRelevantThreshold": 0.55,
+            "keywordBoostWeight": 0.65,
+        },
+    }
+
+    conn1 = db.get_connection(config)
+    conn1.close()
+
+    conn2 = db.get_connection(config)
+    try:
+        rows = conn2.execute("PRAGMA table_info(learnings)").fetchall()
+        col_names = {row["name"] for row in rows}
+        assert "access_count" in col_names
+        assert "last_accessed" in col_names
+    finally:
+        conn2.close()

--- a/plugins/compound-learning/tests/test_hit_tracking.py
+++ b/plugins/compound-learning/tests/test_hit_tracking.py
@@ -1,0 +1,200 @@
+"""
+Tests for the hit_tracker module's file write-back logic.
+
+Uses real SQLite and real files (no mocks for internal modules).
+"""
+
+import hashlib
+import sys
+from pathlib import Path
+
+import pytest
+
+PLUGIN_ROOT = str(Path(__file__).parent.parent)
+sys.path.insert(0, PLUGIN_ROOT)
+
+import lib.db as db
+from lib.hit_tracker import record_hits
+
+
+SAMPLE_LEARNING = """\
+# Test Learning Title
+
+**Type:** pattern
+**Topic:** testing
+**Tags:** test, example
+
+## Problem
+
+This is the problem description.
+
+## Solution
+
+This is the solution.
+"""
+
+SAMPLE_LEARNING_WITH_HITS = """\
+# Test Learning Title
+
+**Type:** pattern
+**Topic:** testing
+**Tags:** test, example
+**Hits:** 5
+**Last Accessed:** 2026-01-01
+
+## Problem
+
+This is the problem description.
+
+## Solution
+
+This is the solution.
+"""
+
+
+@pytest.fixture(scope="module")
+def embedding_model():
+    db.get_embedding("warmup")
+    yield
+
+
+@pytest.fixture()
+def tmp_db(tmp_path, embedding_model):
+    db_path = str(tmp_path / "test.db")
+    config = {
+        "sqlite": {"dbPath": db_path},
+        "learnings": {
+            "globalDir": str(tmp_path / "learnings"),
+            "repoSearchPath": str(tmp_path),
+            "highConfidenceThreshold": 0.40,
+            "possiblyRelevantThreshold": 0.55,
+            "keywordBoostWeight": 0.65,
+        },
+    }
+    conn = db.get_connection(config)
+    yield config, conn, tmp_path
+    conn.close()
+
+
+def _make_result(file_path: Path):
+    doc_id = hashlib.md5(str(file_path.resolve()).encode()).hexdigest()
+    return [{
+        "id": doc_id,
+        "document": "test content",
+        "metadata": {"file_path": str(file_path)},
+        "distance": 0.3,
+    }]
+
+
+def test_record_hits_adds_hits_to_new_file(tmp_db):
+    config, conn, tmp_path = tmp_db
+    tmp_file = tmp_path / "learning-new.md"
+    tmp_file.write_text(SAMPLE_LEARNING, encoding="utf-8")
+
+    doc_id = hashlib.md5(str(tmp_file.resolve()).encode()).hexdigest()
+    db.upsert_document(conn, doc_id, "test content", {
+        "scope": "global", "repo": "", "file_path": str(tmp_file),
+        "topic": "testing", "keywords": "test",
+    })
+
+    results = _make_result(tmp_file)
+    record_hits(config, results, today="2026-03-13")
+
+    content = tmp_file.read_text(encoding="utf-8")
+    assert "**Hits:** 1" in content
+    assert "**Last Accessed:** 2026-03-13" in content
+
+
+def test_record_hits_increments_existing(tmp_db):
+    config, conn, tmp_path = tmp_db
+    tmp_file = tmp_path / "learning-existing.md"
+    tmp_file.write_text(SAMPLE_LEARNING_WITH_HITS, encoding="utf-8")
+
+    doc_id = hashlib.md5(str(tmp_file.resolve()).encode()).hexdigest()
+    db.upsert_document(conn, doc_id, "test content", {
+        "scope": "global", "repo": "", "file_path": str(tmp_file),
+        "topic": "testing", "keywords": "test", "access_count": 5,
+    })
+
+    results = _make_result(tmp_file)
+    record_hits(config, results, today="2026-03-13")
+
+    content = tmp_file.read_text(encoding="utf-8")
+    assert "**Hits:** 6" in content
+    assert "**Hits:** 5" not in content
+
+
+def test_record_hits_updates_last_accessed(tmp_db):
+    config, conn, tmp_path = tmp_db
+    tmp_file = tmp_path / "learning-date.md"
+    tmp_file.write_text(SAMPLE_LEARNING_WITH_HITS, encoding="utf-8")
+
+    doc_id = hashlib.md5(str(tmp_file.resolve()).encode()).hexdigest()
+    db.upsert_document(conn, doc_id, "test content", {
+        "scope": "global", "repo": "", "file_path": str(tmp_file),
+        "topic": "testing", "keywords": "test",
+    })
+
+    results = _make_result(tmp_file)
+    record_hits(config, results, today="2026-03-13")
+
+    content = tmp_file.read_text(encoding="utf-8")
+    assert "**Last Accessed:** 2026-03-13" in content
+    assert "**Last Accessed:** 2026-01-01" not in content
+
+
+def test_record_hits_preserves_body(tmp_db):
+    config, conn, tmp_path = tmp_db
+    tmp_file = tmp_path / "learning-body.md"
+    tmp_file.write_text(SAMPLE_LEARNING, encoding="utf-8")
+
+    doc_id = hashlib.md5(str(tmp_file.resolve()).encode()).hexdigest()
+    db.upsert_document(conn, doc_id, "test content", {
+        "scope": "global", "repo": "", "file_path": str(tmp_file),
+        "topic": "testing", "keywords": "test",
+    })
+
+    results = _make_result(tmp_file)
+    record_hits(config, results, today="2026-03-13")
+
+    content = tmp_file.read_text(encoding="utf-8")
+    assert "## Problem" in content
+    assert "This is the problem description." in content
+    assert "## Solution" in content
+    assert "This is the solution." in content
+
+
+def test_record_hits_missing_file_no_raise(tmp_db):
+    config, conn, tmp_path = tmp_db
+    missing_file = tmp_path / "nonexistent.md"
+
+    doc_id = hashlib.md5(str(missing_file.resolve()).encode()).hexdigest()
+    db.upsert_document(conn, doc_id, "test content", {
+        "scope": "global", "repo": "", "file_path": str(missing_file),
+        "topic": "testing", "keywords": "test",
+    })
+
+    results = _make_result(missing_file)
+    record_hits(config, results, today="2026-03-13")
+
+
+def test_record_hits_insertion_position(tmp_db):
+    config, conn, tmp_path = tmp_db
+    tmp_file = tmp_path / "learning-position.md"
+    tmp_file.write_text(SAMPLE_LEARNING, encoding="utf-8")
+
+    doc_id = hashlib.md5(str(tmp_file.resolve()).encode()).hexdigest()
+    db.upsert_document(conn, doc_id, "test content", {
+        "scope": "global", "repo": "", "file_path": str(tmp_file),
+        "topic": "testing", "keywords": "test",
+    })
+
+    results = _make_result(tmp_file)
+    record_hits(config, results, today="2026-03-13")
+
+    content = tmp_file.read_text(encoding="utf-8")
+    tags_pos = content.index("**Tags:**")
+    hits_pos = content.index("**Hits:**")
+    problem_pos = content.index("## Problem")
+    assert hits_pos > tags_pos, "**Hits:** should appear after **Tags:**"
+    assert hits_pos < problem_pos, "**Hits:** should appear before ## Problem"


### PR DESCRIPTION
## Summary

- Add `**Hits:**` and `**Last Accessed:**` frontmatter fields to learning files, incremented when auto-peek returns them
- Add `access_count` and `last_accessed` columns to SQLite `learnings` table with idempotent schema migration
- New `hit_tracker.py` module handles file write-back and DB updates after peek-mode searches
- Indexer reads hit data from files during re-indexing so SQLite can be fully regenerated from files (files remain source of truth)
- 15 new tests covering schema migration, DB operations, file write-back, and edge cases

Closes #63